### PR TITLE
Remove requests auto-install and document dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Scalp
+
+## Installation
+
+Installez les dépendances nécessaires avec :
+
+```bash
+pip install -r requirements.txt
+```
+

--- a/bot.py
+++ b/bot.py
@@ -23,14 +23,9 @@ from urllib.parse import quote
 from typing import Dict, Any, Optional, List
 
 # ---------------------------------------------------------------------------
-# Dépendances (auto-install si absentes, sans terminal)
+# Dépendances
 # ---------------------------------------------------------------------------
-try:
-    import requests
-except ModuleNotFoundError:
-    import subprocess
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
-    import requests
+import requests
 
 # ---------------------------------------------------------------------------
 # Configuration (via variables d'env conseillées sur Paperspace)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- drop automatic `requests` installation from bot
- list `requests` in requirements.txt
- document installing dependencies via `pip install -r requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a80731a48327afd8e64b4722ba66