### PR TITLE
feat: add JSONL logger utility

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -22,6 +22,8 @@ import os, sys, json, time, hmac, hashlib, logging, math
 from urllib.parse import quote
 from typing import Dict, Any, Optional, List
 
+from scalp.logging_utils import get_jsonl_logger
+
 # ---------------------------------------------------------------------------
 # Dépendances (auto-install si absentes, sans terminal)
 # ---------------------------------------------------------------------------
@@ -68,14 +70,12 @@ logging.basicConfig(
         logging.StreamHandler(sys.stdout),
     ],
 )
-LOG_JSONL = open(os.path.join(CONFIG["LOG_DIR"], "bot_events.jsonl"), "a", encoding="utf-8")
 
-def log_event(event: str, payload: Dict[str, Any]):
-    payload = dict(payload or {})
-    payload["event"] = event
-    payload["ts"] = int(time.time() * 1000)
-    LOG_JSONL.write(json.dumps(payload, ensure_ascii=False) + "\n")
-    LOG_JSONL.flush()
+log_event = get_jsonl_logger(
+    os.path.join(CONFIG["LOG_DIR"], "bot_events.jsonl"),
+    max_bytes=5_000_000,
+    backup_count=5,
+)
 
 # ---------------------------------------------------------------------------
 # Client REST Futures (Contract)

--- a/scalp/__init__.py
+++ b/scalp/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities and helpers for Scalp bot."""

--- a/scalp/logging_utils.py
+++ b/scalp/logging_utils.py
@@ -1,0 +1,58 @@
+"""Logging helpers for the Scalp bot."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import time
+from typing import Any, Dict
+
+
+def get_jsonl_logger(path: str, max_bytes: int = 0, backup_count: int = 0):
+    """Return a callable that logs events as JSON lines.
+
+    Parameters
+    ----------
+    path: str
+        Target file path for JSON lines.
+    max_bytes: int, optional
+        If >0, rotate the file when its size exceeds this value.
+    backup_count: int, optional
+        Number of rotated files to keep when ``max_bytes`` is set.
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    log_file = open(path, "a", encoding="utf-8")
+
+    def _close_file() -> None:
+        try:
+            log_file.close()
+        except Exception:
+            pass
+
+    atexit.register(_close_file)
+
+    def _rotate() -> None:
+        nonlocal log_file
+        log_file.close()
+        for i in range(backup_count - 1, 0, -1):
+            src = f"{path}.{i}"
+            dst = f"{path}.{i + 1}"
+            if os.path.exists(src):
+                os.replace(src, dst)
+        os.replace(path, f"{path}.1")
+        log_file = open(path, "a", encoding="utf-8")
+
+    def _log(event: str, payload: Dict[str, Any]) -> None:
+        nonlocal log_file
+        payload = dict(payload or {})
+        payload["event"] = event
+        payload["ts"] = int(time.time() * 1000)
+        line = json.dumps(payload, ensure_ascii=False)
+        if max_bytes and backup_count > 0:
+            if log_file.tell() + len(line) + 1 > max_bytes:
+                _rotate()
+        log_file.write(line + "\n")
+        log_file.flush()
+
+    return _log


### PR DESCRIPTION
## Summary
- add `get_jsonl_logger` helper with optional log rotation
- wire bot to use the JSONL logger and close file at shutdown

## Testing
- `python -m py_compile bot.py scalp/logging_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a815815c8327b1ec235d85516781