### PR TITLE
refactor: pass symbol to position sizing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -265,13 +265,14 @@ def cross(last_fast: float, last_slow: float, prev_fast: float, prev_slow: float
     return 0
 
 def compute_position_size(contract_detail: Dict[str, Any], equity_usdt: float,
-                          price: float, risk_pct: float, leverage: int) -> int:
+                          price: float, risk_pct: float, leverage: int,
+                          symbol: str) -> int:
     contracts = (contract_detail or {}).get("data", [])
     if not isinstance(contracts, list):
         contracts = [contract_detail.get("data")]
     c = None
     for row in contracts:
-        if row and row.get("symbol") == CONFIG["SYMBOL"]:
+        if row and row.get("symbol") == symbol:
             c = row
             break
     if not c:
@@ -366,7 +367,7 @@ def main():
                 price = float(tdata.get("lastPrice"))
 
             vol = compute_position_size(contract_detail, equity_usdt, price,
-                                        cfg["RISK_PCT_EQUITY"], cfg["LEVERAGE"])
+                                        cfg["RISK_PCT_EQUITY"], cfg["LEVERAGE"], symbol)
             if vol <= 0:
                 logging.info("vol calculé = 0; on attend.")
                 time.sleep(cfg["LOOP_SLEEP_SECS"]); continue

--- a/tests/test_compute_position_size.py
+++ b/tests/test_compute_position_size.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules['requests'] = types.ModuleType('requests')
+from bot import compute_position_size
+
+
+def test_compute_position_size_basic():
+    contract_detail = {
+        "data": [
+            {
+                "symbol": "BTC_USDT",
+                "contractSize": 0.01,
+                "volUnit": 1,
+                "minVol": 1,
+            }
+        ]
+    }
+    vol = compute_position_size(contract_detail, equity_usdt=1000, price=50000,
+                                risk_pct=0.01, leverage=10, symbol="BTC_USDT")
+    assert vol == 1
+
+
+def test_compute_position_size_symbol_not_found():
+    contract_detail = {"data": [{"symbol": "ETH_USDT", "contractSize": 0.1}]}
+    with pytest.raises(ValueError):
+        compute_position_size(contract_detail, equity_usdt=1000, price=500,
+                                risk_pct=0.01, leverage=10, symbol="BTC_USDT")


### PR DESCRIPTION
## Summary
- inject `symbol` into `compute_position_size` signature and usage
- drop global CONFIG reference inside position sizing
- add tests for new `compute_position_size` signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a841c36c8327aed249483b0b724d