### PR TITLE
feat: add mock balance for paper trading

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -180,6 +180,17 @@ class MexcFuturesClient:
 
     # --- Comptes & positions
     def get_assets(self) -> Dict[str, Any]:
+        if self.paper_trade:
+            return {
+                "success": True,
+                "code": 0,
+                "data": [
+                    {
+                        "currency": "USDT",
+                        "equity": 100.0,
+                    }
+                ],
+            }
         return self._private_request("GET", "/api/v1/private/account/assets")
 
     def get_positions(self) -> Dict[str, Any]:
@@ -264,7 +275,8 @@ def cross(last_fast: float, last_slow: float, prev_fast: float, prev_slow: float
 
 def compute_position_size(contract_detail: Dict[str, Any], equity_usdt: float,
                           price: float, risk_pct: float, leverage: int,
-                          symbol: str) -> int:
+                          symbol: Optional[str] = None) -> int:
+    symbol = symbol or CONFIG.get("SYMBOL")
     contracts = (contract_detail or {}).get("data", [])
     if not isinstance(contracts, list):
         contracts = [contract_detail.get("data")]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -93,3 +93,11 @@ def test_private_request_http_error(monkeypatch):
     assert resp["success"] is False
     assert resp["status_code"] == 418
     assert "teapot" in resp["error"]
+
+
+def test_get_assets_paper_trade():
+    client = MexcFuturesClient("key", "secret", "https://test", paper_trade=True)
+    assets = client.get_assets()
+    assert assets["success"] is True
+    usdt = next((row for row in assets.get("data", []) if row.get("currency") == "USDT"), None)
+    assert usdt and usdt["equity"] == 100.0


### PR DESCRIPTION
## Summary
- provide mocked 100 USDT balance when paper trading
- allow compute_position_size to default to configured symbol
- test mocked balance handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0cf45ed808327897e4ba05912b153