### PR TITLE
Add simple position coherence backtest

### DIFF
--- a/scalp/metrics.py
+++ b/scalp/metrics.py
@@ -1,6 +1,7 @@
 """Utility metrics for trading calculations."""
 from __future__ import annotations
 
+
 def calc_pnl_pct(entry_price: float, exit_price: float, side: int) -> float:
     """Return percentage PnL between entry and exit prices.
 
@@ -18,3 +19,34 @@ def calc_pnl_pct(entry_price: float, exit_price: float, side: int) -> float:
     if side not in (1, -1):
         raise ValueError("side must be +1 (long) or -1 (short)")
     return (exit_price - entry_price) / entry_price * 100.0 * side
+
+
+def backtest_position(prices: list[float], entry_idx: int, exit_idx: int, side: int) -> bool:
+    """Run a basic backtest to verify a position's coherence.
+
+    Parameters
+    ----------
+    prices: list[float]
+        Sequential list of prices to evaluate.
+    entry_idx: int
+        Index in ``prices`` where the position is opened.
+    exit_idx: int
+        Index in ``prices`` where the position is closed (must be > ``entry_idx``).
+    side: int
+        +1 for long, -1 for short.
+
+    Returns
+    -------
+    bool
+        ``True`` if the resulting PnL is non-negative, meaning the position is
+        coherent with the direction of price movement. ``False`` otherwise.
+    """
+    if side not in (1, -1):
+        raise ValueError("side must be +1 (long) or -1 (short)")
+    if not (0 <= entry_idx < exit_idx < len(prices)):
+        raise ValueError("entry_idx and exit_idx must be valid and entry_idx < exit_idx")
+
+    entry_price = float(prices[entry_idx])
+    exit_price = float(prices[exit_idx])
+    pnl = calc_pnl_pct(entry_price, exit_price, side)
+    return pnl >= 0.0

--- a/tests/test_backtest_position.py
+++ b/tests/test_backtest_position.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from scalp.metrics import backtest_position
+
+
+def test_backtest_position_long():
+    prices = [100.0, 110.0, 120.0]
+    assert backtest_position(prices, 0, 2, 1) is True
+
+
+def test_backtest_position_short():
+    prices = [100.0, 90.0, 80.0]
+    assert backtest_position(prices, 0, 2, -1) is True
+
+
+def test_backtest_position_incoherent():
+    prices = [100.0, 110.0, 120.0]
+    assert backtest_position(prices, 0, 2, -1) is False
+
+
+def test_backtest_position_bad_indices():
+    prices = [100.0, 110.0]
+    with pytest.raises(ValueError):
+        backtest_position(prices, 1, 0, 1)


### PR DESCRIPTION
## Summary
- add `backtest_position` helper to compute PnL on historical prices and check if trade direction is coherent
- test long, short, and invalid scenarios for the new backtest utility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f7a6732483279a54c5af9bbb5ef0