### PR TITLE
feat: scan and filter trading pairs

### DIFF
--- a/scalp/metrics.py
+++ b/scalp/metrics.py
@@ -1,8 +1,8 @@
 """Utility metrics for trading calculations."""
 from __future__ import annotations
 
-def calc_pnl_pct(entry_price: float, exit_price: float, side: int) -> float:
-    """Return percentage PnL between entry and exit prices.
+def calc_pnl_pct(entry_price: float, exit_price: float, side: int, fee_rate: float = 0.0) -> float:
+    """Return percentage PnL between entry and exit prices minus fees.
 
     Parameters
     ----------
@@ -12,9 +12,14 @@ def calc_pnl_pct(entry_price: float, exit_price: float, side: int) -> float:
         Trade exit price (>0).
     side: int
         +1 for long, -1 for short.
+    fee_rate: float, optional
+        Trading fee rate per operation (e.g., 0.0006 for 0.06%). The fee is
+        applied twice (entry + exit).
     """
     if entry_price <= 0 or exit_price <= 0:
         raise ValueError("Prices must be positive")
     if side not in (1, -1):
         raise ValueError("side must be +1 (long) or -1 (short)")
-    return (exit_price - entry_price) / entry_price * 100.0 * side
+    pnl = (exit_price - entry_price) / entry_price * 100.0 * side
+    fee_pct = fee_rate * 2 * 100.0  # entrée + sortie
+    return pnl - fee_pct

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,13 @@
+import pytest
+
+import bot
+
+
+def test_backtest_trades_zero_fee():
+    trades = [
+        {"symbol": "AAA", "entry": 100.0, "exit": 110.0, "side": 1},
+        {"symbol": "BBB", "entry": 100.0, "exit": 90.0, "side": -1},
+    ]
+    pnl = bot.backtest_trades(trades, fee_rate=0.001, zero_fee_pairs=["BBB"])
+    # AAA: 10% - 0.2% fee = 9.8%; BBB: 10% no fee
+    assert pnl == pytest.approx(19.8)

--- a/tests/test_calc_pnl_pct.py
+++ b/tests/test_calc_pnl_pct.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from scalp.metrics import calc_pnl_pct
@@ -10,3 +11,8 @@ def test_calc_pnl_pct_long():
 
 def test_calc_pnl_pct_short():
     assert calc_pnl_pct(100.0, 90.0, -1) == 10.0
+
+
+def test_calc_pnl_pct_with_fee():
+    # 10% move minus 0.1%*2 fees = 9.8%
+    assert calc_pnl_pct(100.0, 110.0, 1, fee_rate=0.001) == pytest.approx(9.8)

--- a/tests/test_pair_selection.py
+++ b/tests/test_pair_selection.py
@@ -1,0 +1,66 @@
+import bot
+
+
+def test_get_trade_pairs():
+    class Client:
+        def get_ticker(self, symbol=None):
+            return {
+                "success": True,
+                "data": [
+                    {"symbol": "BTC_USDT"},
+                    {"symbol": "ETH_USDT"},
+                ],
+            }
+
+    pairs = bot.get_trade_pairs(Client())
+    assert [p["symbol"] for p in pairs] == ["BTC_USDT", "ETH_USDT"]
+
+
+def test_select_top_pairs():
+    class Client:
+        def get_ticker(self, symbol=None):
+            return {
+                "success": True,
+                "data": [
+                    {"symbol": "A", "volume": "1"},
+                    {"symbol": "B", "volume": "3"},
+                    {"symbol": "C", "volume": "2"},
+                ],
+            }
+
+    top = bot.select_top_pairs(Client(), top_n=2)
+    assert [p["symbol"] for p in top] == ["B", "C"]
+
+
+def test_find_trade_positions(monkeypatch):
+    class Client:
+        def __init__(self):
+            self.data = {
+                "AAA": {"data": {"close": [1, 2, 3]}},
+                "BBB": {"data": {"close": [3, 2, 1]}},
+            }
+
+        def get_kline(self, symbol, interval="Min1"):
+            return self.data[symbol]
+
+    pairs = [
+        {"symbol": "AAA", "lastPrice": "1"},
+        {"symbol": "BBB", "lastPrice": "1"},
+    ]
+
+    monkeypatch.setattr(bot, "ema", lambda series, window: series)
+
+    def fake_cross(last_fast, last_slow, prev_fast, prev_slow):
+        if last_fast > prev_fast:
+            return 1
+        if last_fast < prev_fast:
+            return -1
+        return 0
+
+    monkeypatch.setattr(bot, "cross", fake_cross)
+
+    signals = bot.find_trade_positions(Client(), pairs, ema_fast_n=1, ema_slow_n=1)
+    assert signals == [
+        {"symbol": "AAA", "signal": "long", "price": 1.0},
+        {"symbol": "BBB", "signal": "short", "price": 1.0},
+    ]


### PR DESCRIPTION
## Summary
- add helper functions to fetch available pairs, rank them by volume, and detect EMA cross signals
- support fee-aware PnL/backtests with configurable zero-fee pairs and trade fee logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0de91384083278237cbd19666637b