### PR TITLE
Add event notifier and session PnL tracking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,6 +24,7 @@ from typing import Dict, Any, Optional, List
 
 from scalp.logging_utils import get_jsonl_logger
 from scalp.metrics import calc_pnl_pct
+from scalp.notifier import notify
 
 # ---------------------------------------------------------------------------
 # Dépendances
@@ -468,6 +469,9 @@ def main():
     prev_fast = prev_slow = None
     current_pos = 0  # +1 long, -1 short, 0 flat
     entry_price = None
+    session_pnl = 0.0
+
+    notify("bot_started", {"session_pnl": session_pnl})
 
     while True:
         try:
@@ -522,13 +526,17 @@ def main():
                 if current_pos < 0:
                     if entry_price is not None:
                         pnl = calc_pnl_pct(entry_price, price, -1, fee_rate)
-                        log_event("position_closed", {
+                        payload = {
                             "side": "short",
                             "entry": entry_price,
                             "exit": price,
                             "pnl_pct": pnl,
                             "fee_pct": fee_rate * 2 * 100,
-                        })
+                        }
+                        log_event("position_closed", payload)
+                        session_pnl += pnl
+                        payload["session_pnl"] = session_pnl
+                        notify("position_closed", payload)
                     client.place_order(symbol, side=2, vol=vol, order_type=5, price=price,
                                        open_type=CONFIG["OPEN_TYPE"], leverage=CONFIG["LEVERAGE"], reduce_only=True)
                     current_pos = 0
@@ -540,14 +548,17 @@ def main():
                 log_event("order_long", resp)
                 logging.info("→ LONG vol=%s @~%.2f (SL~%.2f / TP~%.2f) [%s]",
                              vol, price, sl_long, tp_long, "paper" if CONFIG["PAPER_TRADE"] else "live")
-                log_event("position_opened", {
+                open_payload = {
                     "side": "long",
                     "price": price,
                     "vol": vol,
                     "sl_pct": CONFIG["STOP_LOSS_PCT"] * 100,
                     "tp_pct": CONFIG["TAKE_PROFIT_PCT"] * 100,
                     "fee_rate": fee_rate,
-                })
+                    "session_pnl": session_pnl,
+                }
+                log_event("position_opened", open_payload)
+                notify("position_opened", open_payload)
                 current_pos = +1
                 entry_price = price
 
@@ -555,34 +566,41 @@ def main():
                 if current_pos > 0:
                     if entry_price is not None:
                         pnl = calc_pnl_pct(entry_price, price, 1, fee_rate)
-                        log_event("position_closed", {
+                        payload = {
                             "side": "long",
                             "entry": entry_price,
                             "exit": price,
                             "pnl_pct": pnl,
                             "fee_pct": fee_rate * 2 * 100,
-                        })
-                    client.place_order(symbol, side=4, vol=vol, order_type=5, price=price,
-                                       open_type=CONFIG["OPEN_TYPE"], leverage=CONFIG["LEVERAGE"], reduce_only=True)
-                    current_pos = 0
-                    entry_price = None
-                    time.sleep(0.3)
-                resp = client.place_order(symbol, side=3, vol=vol, order_type=5, price=price,
-                                          open_type=CONFIG["OPEN_TYPE"], leverage=CONFIG["LEVERAGE"],
-                                          stop_loss=sl_short, take_profit=tp_short)
-                log_event("order_short", resp)
-                logging.info("→ SHORT vol=%s @~%.2f (SL~%.2f / TP~%.2f) [%s]",
-                             vol, price, sl_short, tp_short, "paper" if CONFIG["PAPER_TRADE"] else "live")
-                log_event("position_opened", {
-                    "side": "short",
-                    "price": price,
-                    "vol": vol,
-                    "sl_pct": CONFIG["STOP_LOSS_PCT"] * 100,
-                    "tp_pct": CONFIG["TAKE_PROFIT_PCT"] * 100,
-                    "fee_rate": fee_rate,
-                })
-                current_pos = -1
-                entry_price = price
+                        }
+                        log_event("position_closed", payload)
+                        session_pnl += pnl
+                        payload["session_pnl"] = session_pnl
+                        notify("position_closed", payload)
+                client.place_order(symbol, side=4, vol=vol, order_type=5, price=price,
+                                   open_type=CONFIG["OPEN_TYPE"], leverage=CONFIG["LEVERAGE"], reduce_only=True)
+                current_pos = 0
+                entry_price = None
+                time.sleep(0.3)
+            resp = client.place_order(symbol, side=3, vol=vol, order_type=5, price=price,
+                                      open_type=CONFIG["OPEN_TYPE"], leverage=CONFIG["LEVERAGE"],
+                                      stop_loss=sl_short, take_profit=tp_short)
+            log_event("order_short", resp)
+            logging.info("→ SHORT vol=%s @~%.2f (SL~%.2f / TP~%.2f) [%s]",
+                         vol, price, sl_short, tp_short, "paper" if CONFIG["PAPER_TRADE"] else "live")
+            open_payload = {
+                "side": "short",
+                "price": price,
+                "vol": vol,
+                "sl_pct": CONFIG["STOP_LOSS_PCT"] * 100,
+                "tp_pct": CONFIG["TAKE_PROFIT_PCT"] * 100,
+                "fee_rate": fee_rate,
+                "session_pnl": session_pnl,
+            }
+            log_event("position_opened", open_payload)
+            notify("position_opened", open_payload)
+            current_pos = -1
+            entry_price = price
 
             time.sleep(cfg["LOOP_SLEEP_SECS"])
 
@@ -592,6 +610,7 @@ def main():
         except Exception as e:
             logging.exception("Erreur boucle principale: %s", str(e))
             time.sleep(3)
+    notify("bot_stopped", {"session_pnl": session_pnl})
 
 if __name__ == "__main__":
     main()

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -1,0 +1,30 @@
+"""Simple HTTP notifier for bot events."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+import requests
+
+
+def notify(event: str, payload: Dict[str, Any] | None = None) -> None:
+    """Send an event payload to the URL defined by ``NOTIFY_URL``.
+
+    If the ``NOTIFY_URL`` environment variable is absent, the function does
+    nothing. Network errors are logged but otherwise ignored so they don't
+    interrupt the bot's execution.
+    """
+    url = os.getenv("NOTIFY_URL")
+    if not url:
+        logging.debug("NOTIFY_URL not set; skipping notification for %s", event)
+        return
+
+    data = {"event": event}
+    if payload:
+        data.update(payload)
+
+    try:
+        requests.post(url, json=data, timeout=5)
+    except Exception as exc:  # pragma: no cover - best effort only
+        logging.error("Notification error for %s: %s", event, exc)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,30 @@
+import scalp.notifier as notifier
+
+
+def test_notify_skips_without_url(monkeypatch):
+    called = False
+
+    def fake_post(url, json=None, timeout=5):  # pragma: no cover - fallback
+        nonlocal called
+        called = True
+
+    monkeypatch.delenv("NOTIFY_URL", raising=False)
+    monkeypatch.setattr(notifier.requests, "post", fake_post)
+    notifier.notify("test", {"foo": 1})
+    assert called is False
+
+
+def test_notify_posts(monkeypatch):
+    payload = {}
+
+    def fake_post(url, json=None, timeout=5):
+        payload["url"] = url
+        payload["json"] = json
+        payload["timeout"] = timeout
+
+    monkeypatch.setenv("NOTIFY_URL", "http://example.com")
+    monkeypatch.setattr(notifier.requests, "post", fake_post)
+    notifier.notify("evt", {"bar": 2})
+    assert payload["url"] == "http://example.com"
+    assert payload["json"]["event"] == "evt"
+    assert payload["json"]["bar"] == 2


### PR DESCRIPTION
## Summary
- add `notify` helper to send bot events to an optional `NOTIFY_URL`
- track session PnL and emit notifications for bot start, position changes, and stop
- cover notifier behavior with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a176d983a08327bc12dccb56fa82f6