### PR TITLE
feat: send notifications to telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Le bot lit sa configuration via des variables d'environnement :
 - `EMA_FAST`, `EMA_SLOW` : périodes des EMA utilisées par la stratégie.
 - `RISK_PCT_EQUITY`, `LEVERAGE`, `STOP_LOSS_PCT`, `TAKE_PROFIT_PCT` : paramètres de gestion du risque.
 - `LOG_DIR` : dossier où seront écrits les fichiers de log.
+- `NOTIFY_URL` : URL d'un webhook HTTP pour recevoir les événements (optionnel).
+- `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` : pour envoyer les notifications sur Telegram (optionnel).
 
 Exemple :
 

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -1,4 +1,4 @@
-"""Simple HTTP notifier for bot events."""
+"""Simple notifier for bot events."""
 from __future__ import annotations
 
 import logging
@@ -8,23 +8,44 @@ from typing import Any, Dict
 import requests
 
 
-def notify(event: str, payload: Dict[str, Any] | None = None) -> None:
-    """Send an event payload to the URL defined by ``NOTIFY_URL``.
+def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:
+    """Return a human readable text describing the event payload."""
+    text = event
+    if payload:
+        items = ", ".join(f"{k}={v}" for k, v in payload.items())
+        text = f"{text} {items}"
+    return text
 
-    If the ``NOTIFY_URL`` environment variable is absent, the function does
-    nothing. Network errors are logged but otherwise ignored so they don't
-    interrupt the bot's execution.
+
+def notify(event: str, payload: Dict[str, Any] | None = None) -> None:
+    """Send an event payload to configured endpoints.
+
+    Notifications can be delivered via a generic HTTP endpoint defined by
+    ``NOTIFY_URL`` and/or directly to Telegram when ``TELEGRAM_BOT_TOKEN`` and
+    ``TELEGRAM_CHAT_ID`` are provided. Missing configuration for one notifier
+    doesn't affect the others. Network errors are logged but otherwise ignored
+    so they don't interrupt the bot's execution.
     """
-    url = os.getenv("NOTIFY_URL")
-    if not url:
-        logging.debug("NOTIFY_URL not set; skipping notification for %s", event)
-        return
 
     data = {"event": event}
     if payload:
         data.update(payload)
 
-    try:
-        requests.post(url, json=data, timeout=5)
-    except Exception as exc:  # pragma: no cover - best effort only
-        logging.error("Notification error for %s: %s", event, exc)
+    # Generic HTTP webhook
+    url = os.getenv("NOTIFY_URL")
+    if url:
+        try:
+            requests.post(url, json=data, timeout=5)
+        except Exception as exc:  # pragma: no cover - best effort only
+            logging.error("Notification error for %s: %s", event, exc)
+
+    # Telegram bot notification
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if token and chat_id:
+        tg_url = f"https://api.telegram.org/bot{token}/sendMessage"
+        tg_payload = {"chat_id": chat_id, "text": _format_text(event, payload)}
+        try:
+            requests.post(tg_url, json=tg_payload, timeout=5)
+        except Exception as exc:  # pragma: no cover - best effort only
+            logging.error("Telegram notification error for %s: %s", event, exc)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -9,6 +9,8 @@ def test_notify_skips_without_url(monkeypatch):
         called = True
 
     monkeypatch.delenv("NOTIFY_URL", raising=False)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
     monkeypatch.setattr(notifier.requests, "post", fake_post)
     notifier.notify("test", {"foo": 1})
     assert called is False
@@ -22,9 +24,31 @@ def test_notify_posts(monkeypatch):
         payload["json"] = json
         payload["timeout"] = timeout
 
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
     monkeypatch.setenv("NOTIFY_URL", "http://example.com")
     monkeypatch.setattr(notifier.requests, "post", fake_post)
     notifier.notify("evt", {"bar": 2})
     assert payload["url"] == "http://example.com"
     assert payload["json"]["event"] == "evt"
     assert payload["json"]["bar"] == 2
+
+
+def test_notify_posts_telegram(monkeypatch):
+    calls = []
+
+    def fake_post(url, json=None, timeout=5):
+        calls.append({"url": url, "json": json, "timeout": timeout})
+
+    monkeypatch.delenv("NOTIFY_URL", raising=False)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+    monkeypatch.setattr(notifier.requests, "post", fake_post)
+
+    notifier.notify("evt", {"bar": 2})
+
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://api.telegram.org/botabc/sendMessage"
+    assert calls[0]["json"]["chat_id"] == "123"
+    assert calls[0]["json"]["text"].startswith("evt")
+    assert "bar" in calls[0]["json"]["text"]


### PR DESCRIPTION
## Summary
- allow notifier to deliver events to Telegram using TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID
- document webhook and Telegram notification environment variables
- cover Telegram notifications with new unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1783d1bd08327bcd259e906f6e5df