### PR TITLE
Guard notifier against missing requests dependency

### DIFF
--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -5,7 +5,21 @@ import logging
 import os
 from typing import Any, Dict
 
-import requests
+try:  # pragma: no cover - guarded import for optional dependency
+    import requests as _requests
+    # ``requests`` may be provided as a stub during tests. Ensure it exposes a
+    # ``post`` attribute so callers can monkeypatch it reliably.
+    if not hasattr(_requests, "post"):
+        raise ImportError
+    requests = _requests
+except Exception:  # pragma: no cover - fallback when ``requests`` is missing
+    class _Requests:
+        """Minimal stand‑in for :mod:`requests` when the real library is absent."""
+
+        def post(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - safety
+            raise RuntimeError("requests.post unavailable")
+
+    requests = _Requests()  # type: ignore[assignment]
 
 
 def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:


### PR DESCRIPTION
## Summary
- make notifier resilient to environments lacking the requests library
- provide minimal fallback implementation so tests and runtime can patch `post`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a179b06fa08327bc350bc4fe64c358