### PR TITLE
feat: load env from parent directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Le bot lit sa configuration via des variables d'environnement :
 - `NOTIFY_URL` : URL d'un webhook HTTP pour recevoir les événements (optionnel, peut être utilisé en plus de Telegram).
 - `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` : pour envoyer les notifications sur Telegram (optionnel, peut être combiné avec le webhook).
 
+Pour éviter de versionner vos clés sensibles, vous pouvez créer un fichier
+`.env` dans le dossier parent du dépôt (par exemple `Notebooks/.env` si le
+code se trouve dans `Notebooks/scalp`).  Ce fichier est automatiquement chargé
+au démarrage et toutes les variables qu'il contient seront disponibles pour le
+bot.
+
 
 Exemple :
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+python-dotenv

--- a/scalp/__init__.py
+++ b/scalp/__init__.py
@@ -1,4 +1,39 @@
-"""Utilities and helpers for Scalp bot."""
+"""Utilities and helpers for Scalp bot.
+
+This module also looks for a ``.env`` file located one directory above the
+repository (e.g. ``Notebooks/.env`` when the project lives in
+``Notebooks/scalp``) and loads any variables found there.  This allows users to
+store private API keys outside of the git repository while still making them
+available to the bot at runtime.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _load_parent_env() -> None:
+    """Load environment variables from ``../.env`` if present."""
+
+    env_file = Path(__file__).resolve().parents[2] / ".env"
+    if not env_file.exists():
+        return
+
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file)
+    except Exception:  # pragma: no cover - optional dependency
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip().strip("'\""))
+
+
+_load_parent_env()
 
 from .version import get_version, bump_version_from_message
 

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,31 @@
+"""Tests for loading environment variables from parent .env file."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+
+def test_parent_env_loaded(tmp_path) -> None:
+    """Module should load variables from ``../.env`` if present."""
+
+    parent = Path(__file__).resolve().parents[2]
+    env_file = parent / ".env"
+    env_file.write_text("MEXC_ACCESS_KEY=from_env\n")
+
+    # Ensure any previous value is cleared then reload the package to trigger
+    # the loading logic.
+    old = os.environ.pop("MEXC_ACCESS_KEY", None)
+    import scalp
+
+    importlib.reload(scalp)
+
+    try:
+        assert os.getenv("MEXC_ACCESS_KEY") == "from_env"
+    finally:
+        env_file.unlink(missing_ok=True)
+        if old is None:
+            os.environ.pop("MEXC_ACCESS_KEY", None)
+        else:
+            os.environ["MEXC_ACCESS_KEY"] = old

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -72,3 +72,37 @@ def test_notify_posts_both(monkeypatch):
     assert calls[0]["url"] == "http://example.com"
     assert calls[1]["url"] == "https://api.telegram.org/botabc/sendMessage"
 
+
+def test_format_text_open_position():
+    payload = {
+        "side": "long",
+        "symbol": "BTCUSDT",
+        "vol": 1,
+        "leverage": 10,
+        "tp_pct": 5,
+        "sl_pct": 2,
+        "hold": "2h",
+    }
+    text = notifier._format_text("position_opened", payload)
+    assert "Ouvre long BTCUSDT" in text
+    assert "Position 1 x10" in text
+    assert "TP +5% / SL -2%" in text
+    assert "durée prévue 2h" in text
+
+
+def test_format_text_closed_position():
+    payload = {
+        "side": "short",
+        "symbol": "ETHUSDT",
+        "vol": 2,
+        "leverage": 5,
+        "pnl_usd": 12,
+        "pnl_pct": 3,
+        "duration": "1h",
+    }
+    text = notifier._format_text("position_closed", payload)
+    assert "Ferme short ETHUSDT" in text
+    assert "Position 2 x5" in text
+    assert "PnL 12 USDT (3%)" in text
+    assert "durée 1h" in text
+


### PR DESCRIPTION
## Summary
- load environment variables from `../.env` to keep API keys out of the repo
- document external `.env` usage and add python-dotenv dependency
- test and verify parent `.env` loading
- format Telegram notifications for opened and closed positions
- test trade message formatting

## Testing
- `python -m pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement python-dotenv)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1907cb19c8327b7e6bd68e835fab0