### PR TITLE
Fix notifier indentation and clean imports

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,8 +27,6 @@ from scalp.metrics import calc_pnl_pct
 from scalp.notifier import notify
 from scalp import __version__
 
-from scalp import __version__
-
 # ---------------------------------------------------------------------------
 # Dépendances
 # ---------------------------------------------------------------------------

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -34,33 +34,6 @@ def _pair_name(symbol: str) -> str:
     return f"{base}/{quote}" if quote else base
 
 
-        if payload:
-            vol = payload.get("vol")
-            lev = payload.get("leverage")
-            if vol is not None and lev is not None:
-                text += f" - Position {vol} x{lev}"
-
-            if event == "position_opened":
-                tp = payload.get("tp_pct")
-                sl = payload.get("sl_pct")
-                if tp is not None and sl is not None:
-                    text += f" - TP +{tp}% / SL -{sl}%"
-                hold = payload.get("hold") or payload.get("expected_duration")
-                if hold is not None:
-                    text += f" - durée prévue {hold}"
-            else:  # position_closed
-                pnl_usd = payload.get("pnl_usd")
-                pnl_pct = payload.get("pnl_pct")
-                if pnl_usd is not None and pnl_pct is not None:
-                    text += f" - PnL {pnl_usd} USDT ({pnl_pct}%)"
-                elif pnl_pct is not None:
-                    text += f" - PnL {pnl_pct}%"
-                dur = payload.get("duration")
-                if dur is not None:
-                    text += f" - durée {dur}"
-        return text
-
-
 def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:
     """Return a human readable text describing the event payload."""
     if event in {"position_opened", "position_closed"}:


### PR DESCRIPTION
## Summary
- remove stray block in notifier causing indentation error
- deduplicate bot imports and keep notifier import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2d46669308327b1a773aaeca5dca5