### PR TITLE
feat: add RSI and ATR calculations

### DIFF
--- a/scalp/metrics.py
+++ b/scalp/metrics.py
@@ -1,6 +1,8 @@
 """Utility metrics for trading calculations."""
 from __future__ import annotations
 
+from typing import Sequence
+
 
 def calc_pnl_pct(entry_price: float, exit_price: float, side: int, fee_rate: float = 0.0) -> float:
     """Return percentage PnL between entry and exit prices minus fees.
@@ -26,6 +28,84 @@ def calc_pnl_pct(entry_price: float, exit_price: float, side: int, fee_rate: flo
     pnl = (exit_price - entry_price) / entry_price * 100.0 * side
     fee_pct = fee_rate * 2 * 100.0  # entrée + sortie
     return pnl - fee_pct
+
+
+def calc_rsi(prices: Sequence[float], period: int = 14) -> float:
+    """Compute the Relative Strength Index (RSI).
+
+    Parameters
+    ----------
+    prices:
+        Ordered sequence of closing prices.
+    period:
+        Number of periods to use for the calculation. Must be positive and the
+        length of ``prices`` must be at least ``period + 1``.
+    """
+
+    if period <= 0:
+        raise ValueError("period must be positive")
+    if len(prices) < period + 1:
+        raise ValueError("len(prices) must be >= period + 1")
+
+    gains: list[float] = []
+    losses: list[float] = []
+    for i in range(1, period + 1):
+        diff = prices[i] - prices[i - 1]
+        if diff >= 0:
+            gains.append(diff)
+            losses.append(0.0)
+        else:
+            gains.append(0.0)
+            losses.append(-diff)
+
+    avg_gain = sum(gains) / period
+    avg_loss = sum(losses) / period
+
+    for i in range(period + 1, len(prices)):
+        diff = prices[i] - prices[i - 1]
+        gain = max(diff, 0.0)
+        loss = max(-diff, 0.0)
+        avg_gain = (avg_gain * (period - 1) + gain) / period
+        avg_loss = (avg_loss * (period - 1) + loss) / period
+
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100.0 - (100.0 / (1.0 + rs))
+
+
+def calc_atr(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float], period: int = 14) -> float:
+    """Compute the Average True Range (ATR).
+
+    Parameters
+    ----------
+    highs, lows, closes:
+        Ordered sequences of high, low and close prices. All sequences must
+        have the same length and contain at least ``period + 1`` elements.
+    period:
+        Number of periods to use for the calculation. Must be positive.
+    """
+
+    if not (len(highs) == len(lows) == len(closes)):
+        raise ValueError("Input sequences must have the same length")
+    if period <= 0:
+        raise ValueError("period must be positive")
+    if len(highs) < period + 1:
+        raise ValueError("len(highs) must be >= period + 1")
+
+    trs: list[float] = []
+    for i in range(1, len(highs)):
+        tr = max(
+            highs[i] - lows[i],
+            abs(highs[i] - closes[i - 1]),
+            abs(lows[i] - closes[i - 1]),
+        )
+        trs.append(tr)
+
+    atr = sum(trs[:period]) / period
+    for tr in trs[period:]:
+        atr = (atr * (period - 1) + tr) / period
+    return atr
 
 
 def backtest_position(prices: list[float], entry_idx: int, exit_idx: int, side: int) -> bool:

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from scalp.metrics import calc_rsi, calc_atr
+
+
+def test_calc_rsi_uptrend():
+    prices = list(range(1, 16))  # strictly increasing
+    assert calc_rsi(prices, period=14) == pytest.approx(100.0)
+
+
+def test_calc_rsi_downtrend():
+    prices = list(range(15, 0, -1))  # strictly decreasing
+    assert calc_rsi(prices, period=14) == pytest.approx(0.0)
+
+
+def test_calc_atr_constant_range():
+    highs = [10, 11, 12, 13, 14]
+    lows = [9, 10, 11, 12, 13]
+    closes = [9.5, 10.5, 11.5, 12.5, 13.5]
+    assert calc_atr(highs, lows, closes, period=3) == pytest.approx(1.5)


### PR DESCRIPTION
## Summary
- add RSI and ATR calculation helpers in `metrics`
- test RSI and ATR utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2d4da06e883279b8c803d6cf14f0a