### PR TITLE
style: format modules and remove merge marker

### DIFF
--- a/scalp/client.py
+++ b/scalp/client.py
@@ -29,7 +29,15 @@ class HttpClient:
             total=max_retries,
             backoff_factor=backoff_factor,
             status_forcelist=status_forcelist or [429, 500, 502, 503, 504],
-            allowed_methods=["HEAD", "GET", "OPTIONS", "POST", "PUT", "DELETE", "PATCH"],
+            allowed_methods=[
+                "HEAD",
+                "GET",
+                "OPTIONS",
+                "POST",
+                "PUT",
+                "DELETE",
+                "PATCH",
+            ],
         )
         adapter = HTTPAdapter(max_retries=retry)
         self.session.mount("http://", adapter)

--- a/scalp/metrics.py
+++ b/scalp/metrics.py
@@ -1,4 +1,5 @@
 """Utility metrics for trading calculations."""
+
 from __future__ import annotations
 
 
@@ -7,8 +8,9 @@ from typing import Iterable, Sequence
 __all__ = ["calc_pnl_pct", "calc_rsi", "calc_atr", "backtest_position"]
 
 
-
-def calc_pnl_pct(entry_price: float, exit_price: float, side: int, fee_rate: float = 0.0) -> float:
+def calc_pnl_pct(
+    entry_price: float, exit_price: float, side: int, fee_rate: float = 0.0
+) -> float:
     """Return percentage PnL between entry and exit prices minus fees.
 
 
@@ -34,7 +36,6 @@ def calc_pnl_pct(entry_price: float, exit_price: float, side: int, fee_rate: flo
     return pnl - fee_pct
 
 
-
 def calc_rsi(prices: Iterable[float], period: int = 14) -> float:
     """Compute the Relative Strength Index (RSI) using Wilder's smoothing.
 
@@ -47,7 +48,6 @@ def calc_rsi(prices: Iterable[float], period: int = 14) -> float:
         Number of periods to use for the calculation. Must be positive and the
         length of ``prices`` must be at least ``period + 1``.
     """
-
 
     prices_list = [float(p) for p in prices]
 
@@ -73,7 +73,6 @@ def calc_rsi(prices: Iterable[float], period: int = 14) -> float:
     avg_gain = sum(gains) / period
     avg_loss = sum(losses) / period
 
-
     for i in range(period + 1, len(prices_list)):
         diff = prices_list[i] - prices_list[i - 1]
 
@@ -82,20 +81,22 @@ def calc_rsi(prices: Iterable[float], period: int = 14) -> float:
         avg_gain = (avg_gain * (period - 1) + gain) / period
         avg_loss = (avg_loss * (period - 1) + loss) / period
 
-
     if avg_gain == 0 and avg_loss == 0:
         return 50.0
     if avg_loss == 0:
         return 100.0
     if avg_gain == 0:
         return 0.0
->>>>>> main
     rs = avg_gain / avg_loss
     return 100.0 - (100.0 / (1.0 + rs))
 
 
-
-def calc_atr(highs: Iterable[float], lows: Iterable[float], closes: Iterable[float], period: int = 14) -> float:
+def calc_atr(
+    highs: Iterable[float],
+    lows: Iterable[float],
+    closes: Iterable[float],
+    period: int = 14,
+) -> float:
     """Compute the Average True Range (ATR) using Wilder's smoothing.
 
 
@@ -107,7 +108,6 @@ def calc_atr(highs: Iterable[float], lows: Iterable[float], closes: Iterable[flo
     period:
         Number of periods to use for the calculation. Must be positive.
     """
-
 
     highs_list = [float(h) for h in highs]
     lows_list = [float(l) for l in lows]
@@ -122,14 +122,12 @@ def calc_atr(highs: Iterable[float], lows: Iterable[float], closes: Iterable[flo
     if length < period + 1:
         raise ValueError("Input sequences must have at least period + 1 elements")
 
-
     trs: list[float] = []
     for i in range(1, len(highs_list)):
         tr = max(
             highs_list[i] - lows_list[i],
             abs(highs_list[i] - closes_list[i - 1]),
             abs(lows_list[i] - closes_list[i - 1]),
-
         )
         trs.append(tr)
 
@@ -139,7 +137,9 @@ def calc_atr(highs: Iterable[float], lows: Iterable[float], closes: Iterable[flo
     return atr
 
 
-def backtest_position(prices: list[float], entry_idx: int, exit_idx: int, side: int) -> bool:
+def backtest_position(
+    prices: list[float], entry_idx: int, exit_idx: int, side: int
+) -> bool:
     """Run a basic backtest to verify a position's coherence.
 
     Parameters
@@ -162,10 +162,11 @@ def backtest_position(prices: list[float], entry_idx: int, exit_idx: int, side: 
     if side not in (1, -1):
         raise ValueError("side must be +1 (long) or -1 (short)")
     if not (0 <= entry_idx < exit_idx < len(prices)):
-        raise ValueError("entry_idx and exit_idx must be valid and entry_idx < exit_idx")
+        raise ValueError(
+            "entry_idx and exit_idx must be valid and entry_idx < exit_idx"
+        )
 
     entry_price = float(prices[entry_idx])
     exit_price = float(prices[exit_idx])
     pnl = calc_pnl_pct(entry_price, exit_price, side)
     return pnl >= 0.0
-

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -1,4 +1,5 @@
 """Simple notifier for bot events."""
+
 from __future__ import annotations
 
 import logging
@@ -7,12 +8,14 @@ from typing import Any, Dict
 
 try:  # pragma: no cover - guarded import for optional dependency
     import requests as _requests
+
     # ``requests`` may be provided as a stub during tests. Ensure it exposes a
     # ``post`` attribute so callers can monkeypatch it reliably.
     if not hasattr(_requests, "post"):
         raise ImportError
     requests = _requests
 except Exception:  # pragma: no cover - fallback when ``requests`` is missing
+
     class _Requests:
         """Minimal stand‑in for :mod:`requests` when the real library is absent."""
 
@@ -20,7 +23,6 @@ except Exception:  # pragma: no cover - fallback when ``requests`` is missing
             raise RuntimeError("requests.post unavailable")
 
     requests = _Requests()  # type: ignore[assignment]
-
 
 
 def _pair_name(symbol: str) -> str:
@@ -75,7 +77,7 @@ def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:
                 if dur is not None:
                     text += f" - durée {dur}"
         return text
-      
+
     text = event
     if payload:
         items = ", ".join(f"{k}={v}" for k, v in payload.items())

--- a/scalp/risk.py
+++ b/scalp/risk.py
@@ -1,4 +1,5 @@
 """Risk management utilities for position sizing."""
+
 from __future__ import annotations
 
 __all__ = ["calc_risk_amount", "calc_position_size"]

--- a/scalp/version.py
+++ b/scalp/version.py
@@ -1,4 +1,5 @@
 """Utilities for managing the Scalp bot version."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -92,4 +93,3 @@ def bump_version_from_git() -> str:
 
 if __name__ == "__main__":
     print(bump_version_from_git())
-


### PR DESCRIPTION
## Summary
- remove stray merge marker from metrics and apply Black formatting
- format client and utility modules for consistent style

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2e5164a248327a7213a2f5f00e469