### PR TITLE
refactor: split bot into reusable modules

### DIFF
--- a/scalp/backtest.py
+++ b/scalp/backtest.py
@@ -1,0 +1,30 @@
+"""Simple backtesting helpers."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from scalp.bot_config import CONFIG
+from scalp.metrics import calc_pnl_pct
+
+
+def backtest_trades(
+    trades: List[Dict[str, Any]],
+    *,
+    fee_rate: Optional[float] = None,
+    zero_fee_pairs: Optional[List[str]] = None,
+) -> float:
+    """Compute cumulative PnL for a series of trades."""
+    fee_rate = fee_rate if fee_rate is not None else CONFIG.get("FEE_RATE", 0.0)
+    zero_fee = set(zero_fee_pairs or CONFIG.get("ZERO_FEE_PAIRS", []))
+
+    pnl = 0.0
+    for tr in trades:
+        symbol = tr.get("symbol")
+        entry = tr.get("entry")
+        exit_ = tr.get("exit")
+        side = tr.get("side", 1)
+        if None in (symbol, entry, exit_):
+            continue
+        frate = 0.0 if symbol in zero_fee else fee_rate
+        pnl += calc_pnl_pct(entry, exit_, side, frate)
+    return pnl

--- a/scalp/bot_config.py
+++ b/scalp/bot_config.py
@@ -1,0 +1,24 @@
+import os
+
+CONFIG = {
+    "MEXC_ACCESS_KEY": os.getenv("MEXC_ACCESS_KEY", "A_METTRE"),
+    "MEXC_SECRET_KEY": os.getenv("MEXC_SECRET_KEY", "B_METTRE"),
+    "PAPER_TRADE": os.getenv("PAPER_TRADE", "true").lower() in ("1", "true", "yes", "y"),
+    "SYMBOL": os.getenv("SYMBOL", "BTC_USDT"),
+    "INTERVAL": os.getenv("INTERVAL", "Min1"),
+    "EMA_FAST": int(os.getenv("EMA_FAST", "9")),
+    "EMA_SLOW": int(os.getenv("EMA_SLOW", "21")),
+    "RISK_PCT_EQUITY": float(os.getenv("RISK_PCT_EQUITY", "0.01")),
+    "LEVERAGE": int(os.getenv("LEVERAGE", "5")),
+    "RISK_LEVEL": int(os.getenv("RISK_LEVEL", "2")),
+    "OPEN_TYPE": int(os.getenv("OPEN_TYPE", "1")),
+    "STOP_LOSS_PCT": float(os.getenv("STOP_LOSS_PCT", "0.006")),
+    "TAKE_PROFIT_PCT": float(os.getenv("TAKE_PROFIT_PCT", "0.012")),
+    "MAX_KLINES": int(os.getenv("MAX_KLINES", "400")),
+    "LOOP_SLEEP_SECS": int(os.getenv("LOOP_SLEEP_SECS", "10")),
+    "RECV_WINDOW": int(os.getenv("RECV_WINDOW", "30")),
+    "LOG_DIR": os.getenv("LOG_DIR", "./logs"),
+    "BASE_URL": os.getenv("MEXC_CONTRACT_BASE_URL", "https://contract.mexc.com"),
+    "FEE_RATE": float(os.getenv("FEE_RATE", "0.0")),
+    "ZERO_FEE_PAIRS": [p.strip() for p in os.getenv("ZERO_FEE_PAIRS", "").split(",") if p.strip()],
+}

--- a/scalp/mexc_client.py
+++ b/scalp/mexc_client.py
@@ -1,0 +1,252 @@
+import json
+import logging
+import time
+import hmac
+import hashlib
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+class MexcFuturesClient:
+    """Lightweight REST client for MEXC futures endpoints."""
+
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        base_url: str,
+        *,
+        recv_window: int = 30,
+        paper_trade: bool = True,
+        requests_module: Any = requests,
+        log_event: Optional[Any] = None,
+    ) -> None:
+        self.ak = access_key
+        self.sk = secret_key
+        self.base = base_url.rstrip("/")
+        self.recv_window = recv_window
+        self.paper_trade = paper_trade
+        self.requests = requests_module
+        self.log_event = log_event or (lambda *a, **k: None)
+        if not self.ak or not self.sk or self.ak == "A_METTRE" or self.sk == "B_METTRE":
+            logging.warning(
+                "\u26a0\ufe0f Cl\u00e9s API non d\u00e9finies. Le mode r\u00e9el ne fonctionnera pas."
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _ms() -> int:
+        return int(time.time() * 1000)
+
+    @staticmethod
+    def _urlencode_sorted(params: Dict[str, Any]) -> str:
+        if not params:
+            return ""
+        items = []
+        for k in sorted(params.keys()):
+            v = "" if params[k] is None else str(params[k])
+            items.append(f"{k}={v}")
+        return "&".join(items)
+
+    def _sign(self, request_param_string: str, req_ms: int) -> str:
+        msg = f"{self.ak}{req_ms}{request_param_string}"
+        return hmac.new(self.sk.encode(), msg.encode(), hashlib.sha256).hexdigest()
+
+    def _headers(self, signature: str, req_ms: int) -> Dict[str, str]:
+        return {
+            "ApiKey": self.ak,
+            "Request-Time": str(req_ms),
+            "Signature": signature,
+            "Content-Type": "application/json",
+            "Recv-Window": str(self.recv_window),
+        }
+
+    # ------------------------------------------------------------------
+    # Public endpoints
+    # ------------------------------------------------------------------
+    def get_contract_detail(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        url = f"{self.base}/api/v1/contract/detail"
+        params: Dict[str, Any] = {}
+        if symbol:
+            params["symbol"] = symbol
+        r = self.requests.get(url, params=params, timeout=15)
+        r.raise_for_status()
+        return r.json()
+
+    def get_kline(
+        self,
+        symbol: str,
+        interval: str = "Min1",
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base}/api/v1/contract/kline/{symbol}"
+        params: Dict[str, Any] = {"interval": interval}
+        if start is not None:
+            params["start"] = int(start)
+        if end is not None:
+            params["end"] = int(end)
+        r = self.requests.get(url, params=params, timeout=15)
+        r.raise_for_status()
+        return r.json()
+
+    def get_ticker(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        url = f"{self.base}/api/v1/contract/ticker"
+        params: Dict[str, Any] = {}
+        if symbol:
+            params["symbol"] = symbol
+        r = self.requests.get(url, params=params, timeout=15)
+        r.raise_for_status()
+        return r.json()
+
+    # ------------------------------------------------------------------
+    # Private endpoints
+    # ------------------------------------------------------------------
+    def _private_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        method = method.upper()
+        url = f"{self.base}{path}"
+        req_ms = self._ms()
+
+        if method in ("GET", "DELETE"):
+            qs = self._urlencode_sorted(params or {})
+            sig = self._sign(qs, req_ms)
+            headers = self._headers(sig, req_ms)
+            r = self.requests.request(method, url, params=params, headers=headers, timeout=20)
+        elif method == "POST":
+            body_str = json.dumps(body or {}, separators=(",", ":"), ensure_ascii=False)
+            sig = self._sign(body_str, req_ms)
+            headers = self._headers(sig, req_ms)
+            r = self.requests.post(url, data=body_str.encode("utf-8"), headers=headers, timeout=20)
+        else:
+            raise ValueError("M\u00e9thode non support\u00e9e")
+
+        try:
+            r.raise_for_status()
+            data = r.json()
+        except Exception as e:  # pragma: no cover - network errors
+            logging.error("Erreur HTTP/JSON %s %s -> %s", method, path, str(e))
+            data = {
+                "success": False,
+                "error": str(e),
+                "status_code": getattr(r, "status_code", None),
+            }
+        self.log_event(
+            "http_private",
+            {"method": method, "path": path, "params": params, "body": body, "response": data},
+        )
+        return data
+
+    # Accounts & positions -------------------------------------------------
+    def get_assets(self) -> Dict[str, Any]:
+        if self.paper_trade:
+            return {
+                "success": True,
+                "code": 0,
+                "data": [
+                    {
+                        "currency": "USDT",
+                        "equity": 100.0,
+                    }
+                ],
+            }
+        return self._private_request("GET", "/api/v1/private/account/assets")
+
+    def get_positions(self) -> Dict[str, Any]:
+        return self._private_request(
+            "GET",
+            "/api/v1/private/position/list/history_positions",
+            params={"page_num": 1, "page_size": 50},
+        )
+
+    def get_open_orders(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        return self._private_request(
+            "GET",
+            "/api/v1/private/order/list/open_orders",
+            params={"symbol": symbol} if symbol else None,
+        )
+
+    # Orders ---------------------------------------------------------------
+    def place_order(
+        self,
+        symbol: str,
+        side: int,
+        vol: int,
+        order_type: int,
+        *,
+        price: Optional[float] = None,
+        open_type: int = 1,
+        leverage: Optional[int] = None,
+        position_id: Optional[int] = None,
+        external_oid: Optional[str] = None,
+        stop_loss: Optional[float] = None,
+        take_profit: Optional[float] = None,
+        reduce_only: Optional[bool] = None,
+        position_mode: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Submit an order."""
+        if self.paper_trade:
+            logging.info(
+                "PAPER_TRADE=True -> ordre simul\u00e9: side=%s vol=%s type=%s price=%s",
+                side,
+                vol,
+                order_type,
+                price,
+            )
+            return {
+                "success": True,
+                "paperTrade": True,
+                "simulated": {
+                    "symbol": symbol,
+                    "side": side,
+                    "vol": vol,
+                    "type": order_type,
+                    "price": price,
+                    "openType": open_type,
+                    "leverage": leverage,
+                    "stopLossPrice": stop_loss,
+                    "takeProfitPrice": take_profit,
+                },
+            }
+
+        body = {
+            "symbol": symbol,
+            "vol": vol,
+            "side": side,
+            "type": order_type,
+            "openType": open_type,
+        }
+        if price is not None:
+            body["price"] = float(price)
+        if leverage is not None:
+            body["leverage"] = int(leverage)
+        if position_id is not None:
+            body["positionId"] = int(position_id)
+        if external_oid:
+            body["externalOid"] = str(external_oid)[:32]
+        if stop_loss is not None:
+            body["stopLossPrice"] = float(stop_loss)
+        if take_profit is not None:
+            body["takeProfitPrice"] = float(take_profit)
+        if reduce_only is not None:
+            body["reduceOnly"] = bool(reduce_only)
+        if position_mode is not None:
+            body["positionMode"] = int(position_mode)
+
+        return self._private_request("POST", "/api/v1/private/order/submit", body=body)
+
+    def cancel_order(self, order_ids: List[int]) -> Dict[str, Any]:
+        return self._private_request("POST", "/api/v1/private/order/cancel", body=order_ids)
+
+    def cancel_all(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        body = {"symbol": symbol} if symbol else {}
+        return self._private_request("POST", "/api/v1/private/order/cancel_all", body=body)

--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -1,0 +1,111 @@
+"""Utilities to select trading pairs and detect signals."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from scalp.bot_config import CONFIG
+from scalp.strategy import ema as default_ema, cross as default_cross
+from scalp.notifier import notify
+
+
+def get_trade_pairs(client: Any) -> List[Dict[str, Any]]:
+    """Return all trading pairs using the client's ``get_ticker`` method."""
+    tick = client.get_ticker()
+    data = tick.get("data") if isinstance(tick, dict) else []
+    if not data:
+        return []
+    return data if isinstance(data, list) else [data]
+
+
+def filter_trade_pairs(
+    client: Any,
+    *,
+    volume_min: float = 5_000_000,
+    max_spread_bps: float = 5.0,
+    zero_fee_pairs: Optional[List[str]] = None,
+    top_n: int = 20,
+) -> List[Dict[str, Any]]:
+    """Filter pairs by volume, spread and zero fees."""
+    pairs = get_trade_pairs(client)
+    zero_fee = set(zero_fee_pairs or CONFIG.get("ZERO_FEE_PAIRS", []))
+    eligible: List[Dict[str, Any]] = []
+
+    for info in pairs:
+        sym = info.get("symbol")
+        if not sym or sym not in zero_fee:
+            continue
+        try:
+            vol = float(info.get("volume", 0))
+        except (TypeError, ValueError):
+            continue
+        if vol < volume_min:
+            continue
+        try:
+            bid = float(info.get("bidPrice", 0))
+            ask = float(info.get("askPrice", 0))
+        except (TypeError, ValueError):
+            continue
+        if bid <= 0 or ask <= 0:
+            continue
+        spread_bps = (ask - bid) / ((ask + bid) / 2) * 10_000
+        if spread_bps >= max_spread_bps:
+            continue
+        eligible.append(info)
+
+    eligible.sort(key=lambda row: float(row.get("volume", 0)), reverse=True)
+    return eligible[:top_n]
+
+
+def select_top_pairs(client: Any, top_n: int = 10, key: str = "volume") -> List[Dict[str, Any]]:
+    """Return ``top_n`` pairs sorted by ``key``."""
+    pairs = get_trade_pairs(client)
+
+    def volume(row: Dict[str, Any]) -> float:
+        try:
+            return float(row.get(key, 0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    pairs.sort(key=volume, reverse=True)
+    return pairs[:top_n]
+
+
+def find_trade_positions(
+    client: Any,
+    pairs: List[Dict[str, Any]],
+    *,
+    interval: str = "Min1",
+    ema_fast_n: Optional[int] = None,
+    ema_slow_n: Optional[int] = None,
+    ema_func=default_ema,
+    cross_func=default_cross,
+) -> List[Dict[str, Any]]:
+    """Apply EMA crossover strategy on ``pairs`` and return signals."""
+    ema_fast_n = ema_fast_n or CONFIG.get("EMA_FAST", 9)
+    ema_slow_n = ema_slow_n or CONFIG.get("EMA_SLOW", 21)
+    results: List[Dict[str, Any]] = []
+
+    for info in pairs:
+        symbol = info.get("symbol")
+        if not symbol:
+            continue
+        k = client.get_kline(symbol, interval=interval)
+        closes = k.get("data", {}).get("close", []) if isinstance(k, dict) else []
+        if len(closes) < max(ema_fast_n, ema_slow_n) + 2:
+            continue
+        efull = ema_func(closes, ema_fast_n)
+        eslow = ema_func(closes, ema_slow_n)
+        signal = cross_func(efull[-1], eslow[-1], efull[-2], eslow[-2])
+        if signal == 1:
+            results.append({"symbol": symbol, "signal": "long", "price": float(info.get("lastPrice", 0.0))})
+        elif signal == -1:
+            results.append({"symbol": symbol, "signal": "short", "price": float(info.get("lastPrice", 0.0))})
+    return results
+
+
+def send_selected_pairs(client: Any, top_n: int = 20) -> None:
+    """Fetch top pairs and notify their list."""
+    pairs = select_top_pairs(client, top_n=top_n)
+    symbols = [p.get("symbol") for p in pairs if p.get("symbol")]
+    if symbols:
+        notify("pair_list", {"pairs": ", ".join(symbols)})

--- a/scalp/strategy.py
+++ b/scalp/strategy.py
@@ -73,6 +73,20 @@ def obv(closes: Sequence[float], volumes: Sequence[float]) -> List[float]:
             out.append(out[-1])
     return out
 
+
+def cross(last_fast: float, last_slow: float, prev_fast: float, prev_slow: float) -> int:
+    """Detect a crossing between two series.
+
+    Returns ``1`` for a bullish crossover, ``-1`` for a bearish crossover and
+    ``0`` otherwise.
+    """
+
+    if prev_fast <= prev_slow and last_fast > last_slow:
+        return 1
+    if prev_fast >= prev_slow and last_fast < last_slow:
+        return -1
+    return 0
+
 # ---------------------------------------------------------------------------
 # Pair selection
 # ---------------------------------------------------------------------------

--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -1,0 +1,77 @@
+"""Utilities for risk analysis and position sizing."""
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+from scalp.bot_config import CONFIG
+
+
+def compute_position_size(
+    contract_detail: Dict[str, Any],
+    equity_usdt: float,
+    price: float,
+    risk_pct: float,
+    leverage: int,
+    symbol: Optional[str] = None,
+) -> int:
+    """Return contract volume to trade for the given risk parameters."""
+    symbol = symbol or CONFIG.get("SYMBOL")
+    contracts = contract_detail.get("data") or []
+    if not isinstance(contracts, list):
+        contracts = [contracts]
+    contract = next((c for c in contracts if c and c.get("symbol") == symbol), None)
+    if contract is None:
+        raise ValueError("Contract detail introuvable pour le symbole")
+
+    contract_size = float(contract.get("contractSize", 0.0001))
+    vol_unit = int(contract.get("volUnit", 1))
+    min_vol = int(contract.get("minVol", 1))
+
+    notional = equity_usdt * float(risk_pct) * float(leverage)
+    if notional <= 0.0:
+        return 0
+    vol = notional / (price * contract_size)
+    vol = int(math.floor(vol / vol_unit) * vol_unit)
+    return max(min_vol, vol)
+
+
+def analyse_risque(
+    contract_detail: Dict[str, Any],
+    open_positions: List[Dict[str, Any]],
+    equity_usdt: float,
+    price: float,
+    risk_pct: float,
+    base_leverage: int,
+    symbol: Optional[str] = None,
+    side: str = "long",
+    risk_level: int = 2,
+) -> Tuple[int, int]:
+    """Analyse le risque avant l'ouverture d'une position."""
+    symbol = symbol or CONFIG.get("SYMBOL")
+    side = side.lower()
+
+    max_positions_map = {1: 1, 2: 2, 3: 3}
+    leverage_map = {1: max(1, base_leverage // 2), 2: base_leverage, 3: base_leverage * 2}
+
+    max_pos = max_positions_map.get(risk_level, max_positions_map[2])
+    leverage = leverage_map.get(risk_level, base_leverage)
+
+    current = 0
+    for pos in open_positions or []:
+        if pos and pos.get("symbol") == symbol:
+            if str(pos.get("side", "")).lower() == side:
+                current += 1
+
+    if current >= max_pos:
+        return 0, leverage
+
+    vol = compute_position_size(
+        contract_detail,
+        equity_usdt=equity_usdt,
+        price=price,
+        risk_pct=risk_pct,
+        leverage=leverage,
+        symbol=symbol,
+    )
+    return vol, leverage


### PR DESCRIPTION
## Summary
- extract runtime configuration to `scalp.bot_config`
- move REST client, pair selection and risk utilities into dedicated modules
- expose helpers from `bot.py` for easier testing and monkeypatching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2e7cdbd9c8327835e77eb743132eb