### PR TITLE
feat: implement strategy v2 filters and utilities

### DIFF
--- a/scalp/backtest.py
+++ b/scalp/backtest.py
@@ -28,3 +28,25 @@ def backtest_trades(
         frate = 0.0 if symbol in zero_fee else fee_rate
         pnl += calc_pnl_pct(entry, exit_, side, frate)
     return pnl
+
+
+def walk_forward_windows(series: List[Any], train: int, test: int):
+    """Yield sequential ``(train, test)`` windows for walk-forward analysis.
+
+    Parameters
+    ----------
+    series:
+        Ordered data sequence.  The function simply slices the input and does
+        not inspect the values.
+    train, test:
+        Number of elements for the training and testing windows respectively.
+    """
+
+    end = len(series) - train - test + 1
+    step = test if test > 0 else 1
+    for start in range(0, max(0, end), step):
+        train_slice = series[start : start + train]
+        test_slice = series[start + train : start + train + test]
+        if len(test_slice) < test or len(train_slice) < train:
+            break
+        yield train_slice, test_slice

--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -75,3 +75,52 @@ def analyse_risque(
         symbol=symbol,
     )
     return vol, leverage
+
+
+def trailing_stop(side: str, current_price: float, atr: float, sl: float, *, mult: float = 0.75) -> float:
+    """Update a stop loss using a trailing ATR multiple."""
+
+    if side.lower() == "long":
+        new_sl = current_price - mult * atr
+        return max(sl, new_sl)
+    new_sl = current_price + mult * atr
+    return min(sl, new_sl)
+
+
+def should_scale_in(
+    entry_price: float,
+    current_price: float,
+    last_entry: float,
+    atr: float,
+    side: str,
+    *,
+    distance_mult: float = 0.5,
+) -> bool:
+    """Return ``True`` when price moved sufficiently to add to the position."""
+
+    if side.lower() == "long":
+        target = last_entry + distance_mult * atr
+        return current_price >= target
+    target = last_entry - distance_mult * atr
+    return current_price <= target
+
+
+def timeout_exit(
+    entry_time: float,
+    now: float,
+    entry_price: float,
+    current_price: float,
+    side: str,
+    *,
+    progress_min: float = 15.0,
+    timeout_min: float = 30.0,
+) -> bool:
+    """Return ``True`` when a position should be closed for lack of progress."""
+
+    elapsed = now - entry_time
+    if elapsed >= timeout_min:
+        return True
+    if elapsed >= progress_min:
+        progress = (current_price - entry_price) if side.lower() == "long" else (entry_price - current_price)
+        return progress <= 0
+    return False

--- a/tests/test_strategy_v2.py
+++ b/tests/test_strategy_v2.py
@@ -1,0 +1,88 @@
+import pytest
+
+from scalp import strategy
+from scalp.trade_utils import trailing_stop, should_scale_in, timeout_exit
+
+
+def make_ohlcv(n=60, start=100, step=1):
+    closes = [start + i * step for i in range(n)]
+    highs = [c + 1 for c in closes]
+    lows = [c - 1 for c in closes]
+    vols = [1 for _ in closes]
+    return {"open": closes, "high": highs, "low": lows, "close": closes, "volume": vols}
+
+
+def test_generate_signal_atr_adaptation(monkeypatch):
+    base = make_ohlcv(step=2)
+    ohlcv_15 = make_ohlcv(n=15, step=2)
+    ohlcv_1h = make_ohlcv(step=2)
+
+    # patches for deterministic RSI values
+    rsi_vals = iter([60, 41, 39])
+    monkeypatch.setattr(strategy, "calc_rsi", lambda *args, **kwargs: next(rsi_vals))
+    monkeypatch.setattr(strategy, "calc_position_size", lambda equity, risk, dist: 100)
+    # low ATR -> signal disabled
+    monkeypatch.setattr(strategy, "calc_atr", lambda *args, **kwargs: 0.1)
+    sig = strategy.generate_signal(
+        "AAA",
+        base,
+        equity=1_000,
+        risk_pct=0.01,
+        ohlcv_15m=ohlcv_15,
+        ohlcv_1h=ohlcv_1h,
+        order_book={"bid_vol_aggreg": 120, "ask_vol_aggreg": 80},
+        tick_ratio_buy=0.6,
+    )
+    assert sig is None
+
+    # high ATR -> size reduced
+    rsi_vals = iter([60, 41, 39])
+    monkeypatch.setattr(strategy, "calc_rsi", lambda *args, **kwargs: next(rsi_vals))
+    monkeypatch.setattr(strategy, "calc_atr", lambda *args, **kwargs: 5.0)
+    sig = strategy.generate_signal(
+        "AAA",
+        base,
+        equity=1_000,
+        risk_pct=0.01,
+        ohlcv_15m=ohlcv_15,
+        ohlcv_1h=ohlcv_1h,
+        order_book={"bid_vol_aggreg": 120, "ask_vol_aggreg": 80},
+        tick_ratio_buy=0.6,
+    )
+    assert sig and sig.side == "long"
+    assert sig.qty == 50
+
+
+def test_generate_signal_short_with_filters(monkeypatch):
+    base = make_ohlcv(start=200, step=-2)
+    ohlcv_15 = make_ohlcv(n=15, start=200, step=-2)
+    ohlcv_1h = make_ohlcv(start=200, step=-2)
+
+    rsi_vals = iter([40, 59, 61])
+    monkeypatch.setattr(strategy, "calc_rsi", lambda *args, **kwargs: next(rsi_vals))
+    monkeypatch.setattr(strategy, "calc_position_size", lambda equity, risk, dist: 100)
+    monkeypatch.setattr(strategy, "calc_atr", lambda *args, **kwargs: 1.0)
+
+    sig = strategy.generate_signal(
+        "AAA",
+        base,
+        equity=1_000,
+        risk_pct=0.01,
+        ohlcv_15m=ohlcv_15,
+        ohlcv_1h=ohlcv_1h,
+        order_book={"bid_vol_aggreg": 80, "ask_vol_aggreg": 120},
+        tick_ratio_buy=0.4,
+    )
+    assert sig and sig.side == "short"
+    assert sig.qty == 100
+
+
+def test_trailing_and_timeout():
+    # trailing stop
+    sl = trailing_stop("long", current_price=110, atr=10, sl=90)
+    assert sl == pytest.approx(102.5)
+    # scaling
+    assert should_scale_in(100, 105, 100, 10, "long") is True
+    # timeout
+    assert timeout_exit(0, 20, 100, 99, "long", progress_min=15, timeout_min=30)
+

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -1,0 +1,11 @@
+from scalp.backtest import walk_forward_windows
+
+
+def test_walk_forward_windows():
+    data = list(range(10))
+    windows = list(walk_forward_windows(data, train=4, test=2))
+    assert windows == [
+        ([0, 1, 2, 3], [4, 5]),
+        ([2, 3, 4, 5], [6, 7]),
+        ([4, 5, 6, 7], [8, 9]),
+    ]


### PR DESCRIPTION
## Summary
- add order book imbalance and swing detection helpers
- extend generate_signal with volatility adaptation, multi-timeframe confirmation, and order book filters
- provide trailing stop, scaling, timeout utilities and walk-forward window generator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2ebff10d08327b9e5fac057deacb2