### PR TITLE
feat: add telegram command system and improve messages

### DIFF
--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -44,44 +44,44 @@ def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:
         symbol = payload.get("symbol") if payload else None
         if symbol:
             symbol = _pair_name(symbol)
-        parts = [p for p in [action, side, symbol] if p]
-        text = " ".join(parts)
+        head = " ".join(p for p in [action, side, symbol] if p)
 
+        lines = [head]
         if payload:
             vol = payload.get("vol")
             lev = payload.get("leverage")
             if vol is not None and lev is not None:
-                text += f" - Position {vol} x{lev}"
+                lines.append(f"Position: {vol} x{lev}")
 
             if event == "position_opened":
                 tp_usd = payload.get("tp_usd")
                 sl_usd = payload.get("sl_usd")
                 if tp_usd is not None and sl_usd is not None:
-                    text += f" - TP +{tp_usd} USDT / SL -{sl_usd} USDT"
+                    lines.append(f"TP: +{tp_usd} USDT / SL: -{sl_usd} USDT")
                 else:
                     tp = payload.get("tp_pct")
                     sl = payload.get("sl_pct")
                     if tp is not None and sl is not None:
-                        text += f" - TP +{tp}% / SL -{sl}%"
+                        lines.append(f"TP: +{tp}% / SL: -{sl}%")
                 hold = payload.get("hold") or payload.get("expected_duration")
                 if hold is not None:
-                    text += f" - durée prévue {hold}"
+                    lines.append(f"Durée prévue: {hold}")
             else:  # position_closed
                 pnl_usd = payload.get("pnl_usd")
                 pnl_pct = payload.get("pnl_pct")
                 if pnl_usd is not None and pnl_pct is not None:
-                    text += f" - PnL {pnl_usd} USDT ({pnl_pct}%)"
+                    lines.append(f"PnL: {pnl_usd} USDT ({pnl_pct}%)")
                 elif pnl_pct is not None:
-                    text += f" - PnL {pnl_pct}%"
+                    lines.append(f"PnL: {pnl_pct}%")
                 dur = payload.get("duration")
                 if dur is not None:
-                    text += f" - durée {dur}"
-        return text
+                    lines.append(f"Durée: {dur}")
+        return "\n".join(lines)
 
     text = event
     if payload:
-        items = ", ".join(f"{k}={v}" for k, v in payload.items())
-        text = f"{text} {items}"
+        items = "\n".join(f"{k}={v}" for k, v in payload.items())
+        text = f"{text}\n{items}"
     return text
 
 

--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import requests as _requests
+    requests = _requests
+except Exception:  # pragma: no cover
+    class _Requests:
+        def get(self, *a: Any, **k: Any) -> Any:  # pragma: no cover - fallback
+            raise RuntimeError("requests.get unavailable")
+
+        def post(self, *a: Any, **k: Any) -> Any:  # pragma: no cover - fallback
+            raise RuntimeError("requests.post unavailable")
+
+    requests = _Requests()  # type: ignore[assignment]
+
+
+class TelegramBot:
+    """Minimal Telegram bot using the HTTP API.
+
+    It polls updates and answers a few text commands allowing the user to
+    inspect the trading session.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        chat_id: str,
+        client: Any,
+        config: Dict[str, Any],
+        *,
+        requests_module: Any = requests,
+    ) -> None:
+        self.token = token
+        self.chat_id = str(chat_id)
+        self.client = client
+        self.config = config
+        self.requests = requests_module
+        self.last_update_id: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    def _api_url(self, method: str) -> str:
+        return f"https://api.telegram.org/bot{self.token}/{method}"
+
+    def send(self, text: str) -> None:
+        payload = {"chat_id": self.chat_id, "text": text}
+        try:  # pragma: no cover - network
+            self.requests.post(self._api_url("sendMessage"), json=payload, timeout=5)
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.error("Telegram send error: %s", exc)
+
+    # ------------------------------------------------------------------
+    def fetch_updates(self) -> list[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if self.last_update_id is not None:
+            params["offset"] = self.last_update_id + 1
+        try:  # pragma: no cover - network
+            r = self.requests.get(self._api_url("getUpdates"), params=params, timeout=5)
+            r.raise_for_status()
+            data = r.json()
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.error("Telegram getUpdates error: %s", exc)
+            return []
+        updates = data.get("result", [])
+        if updates:
+            self.last_update_id = updates[-1].get("update_id")
+        return updates
+
+    # ------------------------------------------------------------------
+    def handle_updates(self, session_pnl: float) -> None:
+        for update in self.fetch_updates():
+            msg = update.get("message") or {}
+            chat = msg.get("chat") or {}
+            if str(chat.get("id")) != self.chat_id:
+                continue
+            text = msg.get("text", "")
+            reply = self.handle_command(text, session_pnl)
+            if reply:
+                self.send(reply)
+
+    # ------------------------------------------------------------------
+    def handle_command(self, text: str, session_pnl: float) -> Optional[str]:
+        if not text:
+            return None
+        parts = text.strip().split()
+        cmd = parts[0].lower()
+        arg = parts[1:] if len(parts) > 1 else []
+
+        if cmd == "/help":
+            return (
+                "Commandes:\n"
+                "/balance - solde compte\n"
+                "/positions - positions ouvertes\n"
+                "/pnl - PnL session\n"
+                "/risk [1-3] - niveau de risque"
+            )
+        if cmd == "/balance":
+            assets = self.client.get_assets()
+            equity = 0.0
+            for row in assets.get("data", []):
+                if row.get("currency") == "USDT":
+                    try:
+                        equity = float(row.get("equity", 0.0))
+                    except Exception:
+                        equity = 0.0
+                    break
+            return f"Solde: {equity} USDT"
+        if cmd == "/positions":
+            pos = self.client.get_positions()
+            lines = []
+            for p in pos.get("data", []):
+                symbol = p.get("symbol")
+                side = p.get("side")
+                vol = p.get("vol")
+                lines.append(f"{symbol} {side} {vol}")
+            if not lines:
+                return "Aucune position ouverte"
+            return "Positions:\n" + "\n".join(lines)
+        if cmd in {"/pnl", "/session"}:
+            return f"PnL session: {session_pnl} USDT"
+        if cmd == "/risk":
+            if arg:
+                try:
+                    lvl = int(arg[0])
+                    if lvl in (1, 2, 3):
+                        self.config["RISK_LEVEL"] = lvl
+                        return f"Niveau de risque réglé sur {lvl}"
+                except ValueError:
+                    pass
+            return f"Niveau de risque actuel: {self.config.get('RISK_LEVEL', 2)}"
+        return "Commande inconnue. Tapez /help"
+
+
+def init_telegram_bot(client: Any, config: Dict[str, Any]) -> Optional[TelegramBot]:
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if token and chat_id:
+        return TelegramBot(token, chat_id, client, config)
+    return None

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -85,11 +85,11 @@ def test_format_text_open_position():
         "hold": "2h",
     }
     text = notifier._format_text("position_opened", payload)
-    assert "Ouvre long BTC/USDT" in text
-    assert "Position 1 x10" in text
-    assert "TP +5 USDT / SL -2 USDT" in text
-
-    assert "durée prévue 2h" in text
+    lines = text.splitlines()
+    assert lines[0] == "Ouvre long BTC/USDT"
+    assert "Position: 1 x10" in lines[1]
+    assert any("TP: +5 USDT / SL: -2 USDT" in l for l in lines)
+    assert any("Durée prévue: 2h" in l for l in lines)
 
 
 def test_format_text_closed_position():
@@ -103,9 +103,9 @@ def test_format_text_closed_position():
         "duration": "1h",
     }
     text = notifier._format_text("position_closed", payload)
-
-    assert "Ferme short ETH/USDT" in text
-    assert "Position 2 x5" in text
-    assert "PnL 12 USDT (3%)" in text
-    assert "durée 1h" in text
+    lines = text.splitlines()
+    assert lines[0] == "Ferme short ETH/USDT"
+    assert any("Position: 2 x5" in l for l in lines)
+    assert any("PnL: 12 USDT (3%)" in l for l in lines)
+    assert any("Durée: 1h" in l for l in lines)
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,50 @@
+from scalp.telegram_bot import TelegramBot
+
+
+class DummyClient:
+    def get_assets(self):
+        return {"data": [{"currency": "USDT", "equity": 123.45}]}
+
+    def get_positions(self):
+        return {"data": [{"symbol": "BTC_USDT", "side": "long", "vol": 2}]}
+
+
+def make_bot(config=None):
+    cfg = {"RISK_LEVEL": 2}
+    if config:
+        cfg.update(config)
+    return TelegramBot("t", "1", DummyClient(), cfg)
+
+
+def test_handle_balance():
+    bot = make_bot()
+    resp = bot.handle_command("/balance", 0.0)
+    assert "123.45" in resp
+
+
+def test_handle_positions():
+    bot = make_bot()
+    resp = bot.handle_command("/positions", 0.0)
+    assert "BTC_USDT" in resp
+    assert "long" in resp
+
+
+def test_handle_pnl():
+    bot = make_bot()
+    resp = bot.handle_command("/pnl", 5.0)
+    assert "5.0" in resp
+
+
+def test_handle_risk_change():
+    bot = make_bot()
+    resp = bot.handle_command("/risk 3", 0.0)
+    assert "3" in resp
+    assert bot.config["RISK_LEVEL"] == 3
+    resp2 = bot.handle_command("/risk", 0.0)
+    assert "3" in resp2
+
+
+def test_handle_unknown():
+    bot = make_bot()
+    resp = bot.handle_command("/foobar", 0.0)
+    assert "inconnue" in resp


### PR DESCRIPTION
## Summary
- add Telegram command bot for querying balance, positions, PnL and risk level
- integrate command handling into main loop
- reformat Telegram notifications with clearer multi-line text

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2ee15dd9083279246faa2bce0a223