### PR TITLE
feat: introduce dynamic risk sizing and pair heat scoring

### DIFF
--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -124,3 +124,32 @@ def timeout_exit(
         progress = (current_price - entry_price) if side.lower() == "long" else (entry_price - current_price)
         return progress <= 0
     return False
+
+
+def marketable_limit_price(
+    side: str,
+    *,
+    best_bid: float,
+    best_ask: float,
+    slippage: float = 0.001,
+) -> float:
+    """Return price for a marketable limit order with slippage cap.
+
+    Parameters
+    ----------
+    side:
+        ``"buy"`` or ``"sell"``.
+    best_bid, best_ask:
+        Current best bid and ask prices.
+    slippage:
+        Maximum relative slippage allowed (e.g. ``0.001`` = 0.1%).
+    """
+
+    if slippage < 0:
+        raise ValueError("slippage must be non-negative")
+    side = side.lower()
+    if side == "buy":
+        return best_ask * (1.0 + slippage)
+    if side == "sell":
+        return best_bid * (1.0 - slippage)
+    raise ValueError("side must be 'buy' or 'sell'")

--- a/scalp/ws.py
+++ b/scalp/ws.py
@@ -1,0 +1,59 @@
+"""Minimal websocket manager with heartbeat and auto-resubscribe.
+
+This module provides a light-weight framework to maintain a realtime
+connection to an exchange.  The actual network layer is expected to be
+supplied by the caller via ``connect`` and ``subscribe`` callbacks.  The
+manager handles retrying failed connections and periodically invoking the
+``subscribe`` callback as a heartbeat.  This keeps the code fully testable
+without opening real network sockets.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional
+
+
+class WebsocketManager:
+    """Maintain a websocket connection with heartbeat and retry."""
+
+    def __init__(
+        self,
+        connect: Callable[[], Awaitable[None]],
+        subscribe: Callable[[], Awaitable[None]],
+        *,
+        heartbeat_interval: float = 30.0,
+        max_retries: int = 3,
+    ) -> None:
+        self._connect = connect
+        self._subscribe = subscribe
+        self.heartbeat_interval = heartbeat_interval
+        self.max_retries = max_retries
+        self._heartbeat_task: Optional[asyncio.Task] = None
+
+    async def run(self) -> None:
+        """Open the connection retrying on failure."""
+        retries = 0
+        while True:
+            try:
+                await self._connect()
+                await self._subscribe()
+                self._heartbeat_task = asyncio.create_task(self._heartbeat())
+                return
+            except Exception as exc:  # pragma: no cover - network errors
+                logging.error("websocket connect failed: %s", exc)
+                retries += 1
+                if retries > self.max_retries:
+                    raise
+                await asyncio.sleep(1)
+
+    async def _heartbeat(self) -> None:
+        """Send periodic heartbeats and resubscribe on failure."""
+        while True:
+            await asyncio.sleep(self.heartbeat_interval)
+            try:
+                await self._subscribe()
+            except Exception as exc:  # pragma: no cover - network errors
+                logging.warning("websocket heartbeat failed: %s", exc)
+                await self.run()
+                break

--- a/tests/test_dynamic_allocation.py
+++ b/tests/test_dynamic_allocation.py
@@ -1,0 +1,17 @@
+import math
+from scalp.risk import adjust_risk_pct
+
+
+def test_adjust_risk_pct_increase_decrease():
+    base = 0.01
+    assert adjust_risk_pct(base, win_streak=2, loss_streak=0) > base
+    assert adjust_risk_pct(base, win_streak=0, loss_streak=2) < base
+
+
+def test_adjust_risk_pct_bounds():
+    assert math.isclose(
+        adjust_risk_pct(0.05, win_streak=2, loss_streak=0, max_pct=0.05), 0.05
+    )
+    assert math.isclose(
+        adjust_risk_pct(0.001, win_streak=0, loss_streak=2, min_pct=0.001), 0.001
+    )

--- a/tests/test_heat_score.py
+++ b/tests/test_heat_score.py
@@ -1,0 +1,21 @@
+from scalp.pairs import heat_score, select_top_heat_pairs, decorrelate_pairs
+
+
+def test_heat_score_value():
+    assert heat_score(2.0, 100.0) == 200.0
+    assert heat_score(2.0, 100.0, news=True) == 400.0
+
+
+def test_select_and_decorrelate_pairs():
+    pairs = [
+        {"symbol": "A", "volatility": 2, "volume": 100, "news": True},
+        {"symbol": "B", "volatility": 1, "volume": 200, "news": False},
+        {"symbol": "C", "volatility": 1.5, "volume": 150, "news": False},
+        {"symbol": "D", "volatility": 3, "volume": 50, "news": True},
+    ]
+    top = select_top_heat_pairs(pairs, top_n=3)
+    assert len(top) == 3
+    corr = {"A": {"B": 0.9}, "B": {"A": 0.9}, "C": {}, "D": {}}
+    selected = decorrelate_pairs(pairs, corr, threshold=0.8, top_n=3)
+    syms = {p["symbol"] for p in selected}
+    assert not ("A" in syms and "B" in syms)

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -1,0 +1,8 @@
+from scalp.trade_utils import marketable_limit_price
+
+
+def test_marketable_limit_price_buy_sell():
+    price_buy = marketable_limit_price("buy", best_bid=9.9, best_ask=10.0, slippage=0.001)
+    assert price_buy == 10.0 * 1.001
+    price_sell = marketable_limit_price("sell", best_bid=9.9, best_ask=10.0, slippage=0.001)
+    assert price_sell == 9.9 * (1 - 0.001)


### PR DESCRIPTION
## Summary
- add simplified Kelly-style risk adjustment utility
- rank pairs by heat score and avoid highly correlated symbols
- provide marketable limit pricing and a minimal websocket manager
- cover new behaviour with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2eebe1f148327a03129474098afb3