### PR TITLE
feat: integrate risk manager with daily loss limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Le bot lit sa configuration via des variables d'environnement :
 - `INTERVAL` : intervalle des chandeliers, ex. `Min1`, `Min5`.
 - `EMA_FAST`, `EMA_SLOW` : périodes des EMA utilisées par la stratégie.
 - `RISK_PCT_EQUITY`, `LEVERAGE`, `STOP_LOSS_PCT`, `TAKE_PROFIT_PCT` : paramètres de gestion du risque.
+- `MAX_DAILY_LOSS_PCT`, `MAX_POSITIONS` : limites globales (kill switch, nombre maximal de positions).
 - `LOG_DIR` : dossier où seront écrits les fichiers de log.
 
 - `NOTIFY_URL` : URL d'un webhook HTTP pour recevoir les événements (optionnel, peut être utilisé en plus de Telegram).

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ import requests
 from scalp.logging_utils import get_jsonl_logger
 from scalp.metrics import calc_pnl_pct
 from scalp.notifier import notify
-from scalp import __version__
+from scalp import __version__, RiskManager
 from scalp.telegram_bot import init_telegram_bot
 
 from scalp.bot_config import CONFIG
@@ -113,6 +113,10 @@ def main() -> None:
         base_url=cfg["BASE_URL"],
         recv_window=cfg["RECV_WINDOW"],
         paper_trade=cfg["PAPER_TRADE"],
+    )
+    risk_mgr = RiskManager(
+        max_daily_loss_pct=cfg["MAX_DAILY_LOSS_PCT"],
+        max_positions=cfg["MAX_POSITIONS"],
     )
 
     tg_bot = init_telegram_bot(client, cfg)
@@ -265,11 +269,23 @@ def main() -> None:
                         leverage=CONFIG["LEVERAGE"],
                         reduce_only=True,
                     )
+                    risk_mgr.record_trade(pnl)
+                    if risk_mgr.kill_switch:
+                        logging.warning("Kill switch activé, arrêt du bot.")
+                        break
+                    pause = risk_mgr.pause_duration()
+                    if pause:
+                        logging.info("Pause %s s après série de pertes", pause)
+                        time.sleep(pause)
                     current_pos = 0
                     entry_price = None
                     time.sleep(0.3)
 
                 positions = client.get_positions().get("data", [])
+                if not risk_mgr.can_open(len(positions)):
+                    logging.info("RiskManager: limites atteintes, on attend.")
+                    time.sleep(cfg["LOOP_SLEEP_SECS"])
+                    continue
                 vol_open, lev = analyse_risque(
                     contract_detail,
                     positions,
@@ -347,11 +363,23 @@ def main() -> None:
                         leverage=CONFIG["LEVERAGE"],
                         reduce_only=True,
                     )
+                    risk_mgr.record_trade(pnl)
+                    if risk_mgr.kill_switch:
+                        logging.warning("Kill switch activé, arrêt du bot.")
+                        break
+                    pause = risk_mgr.pause_duration()
+                    if pause:
+                        logging.info("Pause %s s après série de pertes", pause)
+                        time.sleep(pause)
                     current_pos = 0
                     entry_price = None
                     time.sleep(0.3)
 
                 positions = client.get_positions().get("data", [])
+                if not risk_mgr.can_open(len(positions)):
+                    logging.info("RiskManager: limites atteintes, on attend.")
+                    time.sleep(cfg["LOOP_SLEEP_SECS"])
+                    continue
                 vol_open, lev = analyse_risque(
                     contract_detail,
                     positions,

--- a/scalp/bot_config.py
+++ b/scalp/bot_config.py
@@ -20,5 +20,7 @@ CONFIG = {
     "LOG_DIR": os.getenv("LOG_DIR", "./logs"),
     "BASE_URL": os.getenv("MEXC_CONTRACT_BASE_URL", "https://contract.mexc.com"),
     "FEE_RATE": float(os.getenv("FEE_RATE", "0.0")),
+    "MAX_DAILY_LOSS_PCT": float(os.getenv("MAX_DAILY_LOSS_PCT", "5.0")),
+    "MAX_POSITIONS": int(os.getenv("MAX_POSITIONS", "1")),
     "ZERO_FEE_PAIRS": [p.strip() for p in os.getenv("ZERO_FEE_PAIRS", "").split(",") if p.strip()],
 }

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,21 @@
+from scalp import RiskManager
+
+
+def test_kill_switch_triggered() -> None:
+    rm = RiskManager(max_daily_loss_pct=2.0, max_positions=1)
+    rm.record_trade(-1.0)
+    rm.record_trade(-1.5)
+    assert rm.kill_switch is True
+
+
+def test_pause_and_can_open() -> None:
+    rm = RiskManager(max_daily_loss_pct=10.0, max_positions=1)
+    rm.record_trade(-0.5)
+    rm.record_trade(-0.6)
+    rm.record_trade(-0.7)
+    assert rm.pause_duration() == 15 * 60
+    rm.record_trade(-0.8)
+    rm.record_trade(-0.9)
+    assert rm.pause_duration() == 60 * 60
+    assert rm.can_open(0) is True
+    assert rm.can_open(1) is False


### PR DESCRIPTION
## Summary
- expose MAX_DAILY_LOSS_PCT and MAX_POSITIONS configuration options
- integrate RiskManager into trading loop with kill switch and pauses after loss streaks
- test RiskManager behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2f3b72f5c8327975ca0655e8e5010