### PR TITLE
refactor: filter pair duplicates and simplify config check

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -49,18 +49,16 @@ log_event = get_jsonl_logger(
 
 
 def check_config() -> None:
-    """Display a color coded status of important environment variables."""
+    """Display only missing environment variables."""
     critical = {"MEXC_ACCESS_KEY", "MEXC_SECRET_KEY"}
     optional = {"NOTIFY_URL", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID"}
     all_keys = sorted(set(CONFIG.keys()) | optional)
-    red, orange, green, reset = "\033[91m", "\033[93m", "\033[92m", "\033[0m"
+    red, orange, reset = "\033[91m", "\033[93m", "\033[0m"
     for key in all_keys:
         val = os.getenv(key)
         if key in critical and (not val or val in {"", "A_METTRE", "B_METTRE"}):
-            logging.info("%s%s%s: critique", red, key, reset)
-        elif val:
-            logging.info("%s%s%s: dispo", green, key, reset)
-        else:
+            logging.warning("%s%s%s: critique", red, key, reset)
+        elif not val:
             logging.info("%s%s%s: absente", orange, key, reset)
 
 
@@ -99,22 +97,12 @@ def find_trade_positions(
 
 
 def send_selected_pairs(client: Any, top_n: int = 20) -> None:
-    pairs = select_top_pairs(client, top_n=top_n)
-    seen: set[str] = set()
-    symbols: list[str] = []
-    for p in pairs:
-        sym = p.get("symbol")
-        if not sym:
-            continue
-        base = sym.replace("_", "")
-        if base.endswith("USDT"):
-            base = base[:-4]
-        if base in seen:
-            continue
-        seen.add(base)
-        symbols.append(base)
-    if symbols:
-        notify("pair_list", {"pairs": ", ".join(symbols)})
+    _pairs.send_selected_pairs(
+        client,
+        top_n=top_n,
+        select_fn=select_top_pairs,
+        notify_fn=notify,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -12,15 +12,17 @@ def test_send_selected_pairs(monkeypatch):
     monkeypatch.setattr(
         bot,
         "select_top_pairs",
-        lambda client, top_n=20: [
-            {"symbol": "WIFUSDT"},
-            {"symbol": "WIFUSDT"},
-            {"symbol": "BTCUSDT"},
+        lambda client, top_n=60: [
+            {"symbol": "WIFUSDT", "volume": 10},
+            {"symbol": "WIFUSDT", "volume": 9},
+            {"symbol": "BTCUSD", "volume": 8},
+            {"symbol": "BTCUSDT", "volume": 7},
+            {"symbol": "ETHUSDT", "volume": 6},
         ],
     )
 
     bot.send_selected_pairs(object(), top_n=3)
 
     assert sent["event"] == "pair_list"
-    assert sent["payload"]["pairs"] == "WIF, BTC"
+    assert sent["payload"]["pairs"] == "WIF, BTC, ETH"
 


### PR DESCRIPTION
## Summary
- only log missing environment variables during startup
- remove USD/USDT duplicates when sending top pairs
- test pair list for USD/USDT deduplication

## Testing
- `pytest tests/test_pairs.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2f0def8ec832783b4124d8987d5df