### PR TITLE
refactor: filter pair duplicates and auto-select default symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Le bot lit sa configuration via des variables d'environnement :
 
 - `MEXC_ACCESS_KEY`, `MEXC_SECRET_KEY` : clés API MEXC (laisser les valeurs par défaut pour rester en mode papier).
 - `PAPER_TRADE` (`true`/`false`) : par défaut `true`, n'envoie aucun ordre réel.
-- `SYMBOL` : symbole du contrat futures, ex. `BTC_USDT`.
+- `SYMBOL` : symbole du contrat futures (par défaut, première paire de `ZERO_FEE_PAIRS` ou `BTC_USDT`).
 - `INTERVAL` : intervalle des chandeliers, ex. `Min1`, `Min5`.
 - `EMA_FAST`, `EMA_SLOW` : périodes des EMA utilisées par la stratégie.
 - `RISK_PCT_EQUITY`, `LEVERAGE`, `STOP_LOSS_PCT`, `TAKE_PROFIT_PCT` : paramètres de gestion du risque.

--- a/bot.py
+++ b/bot.py
@@ -49,18 +49,16 @@ log_event = get_jsonl_logger(
 
 
 def check_config() -> None:
-    """Display a color coded status of important environment variables."""
+    """Display only missing environment variables."""
     critical = {"MEXC_ACCESS_KEY", "MEXC_SECRET_KEY"}
     optional = {"NOTIFY_URL", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID"}
     all_keys = sorted(set(CONFIG.keys()) | optional)
-    red, orange, green, reset = "\033[91m", "\033[93m", "\033[92m", "\033[0m"
+    red, orange, reset = "\033[91m", "\033[93m", "\033[0m"
     for key in all_keys:
         val = os.getenv(key)
         if key in critical and (not val or val in {"", "A_METTRE", "B_METTRE"}):
-            logging.info("%s%s%s: critique", red, key, reset)
-        elif val:
-            logging.info("%s%s%s: dispo", green, key, reset)
-        else:
+            logging.warning("%s%s%s: critique", red, key, reset)
+        elif not val:
             logging.info("%s%s%s: absente", orange, key, reset)
 
 
@@ -99,22 +97,12 @@ def find_trade_positions(
 
 
 def send_selected_pairs(client: Any, top_n: int = 20) -> None:
-    pairs = select_top_pairs(client, top_n=top_n)
-    seen: set[str] = set()
-    symbols: list[str] = []
-    for p in pairs:
-        sym = p.get("symbol")
-        if not sym:
-            continue
-        base = sym.replace("_", "")
-        if base.endswith("USDT"):
-            base = base[:-4]
-        if base in seen:
-            continue
-        seen.add(base)
-        symbols.append(base)
-    if symbols:
-        notify("pair_list", {"pairs": ", ".join(symbols)})
+    _pairs.send_selected_pairs(
+        client,
+        top_n=top_n,
+        select_fn=select_top_pairs,
+        notify_fn=notify,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/scalp/bot_config.py
+++ b/scalp/bot_config.py
@@ -1,10 +1,13 @@
 import os
 
+ZERO_FEE_PAIRS = [p.strip() for p in os.getenv("ZERO_FEE_PAIRS", "").split(",") if p.strip()]
+DEFAULT_SYMBOL = os.getenv("SYMBOL") or (ZERO_FEE_PAIRS[0] if ZERO_FEE_PAIRS else "BTC_USDT")
+
 CONFIG = {
     "MEXC_ACCESS_KEY": os.getenv("MEXC_ACCESS_KEY", "A_METTRE"),
     "MEXC_SECRET_KEY": os.getenv("MEXC_SECRET_KEY", "B_METTRE"),
     "PAPER_TRADE": os.getenv("PAPER_TRADE", "true").lower() in ("1", "true", "yes", "y"),
-    "SYMBOL": os.getenv("SYMBOL", "BTC_USDT"),
+    "SYMBOL": DEFAULT_SYMBOL,
     "INTERVAL": os.getenv("INTERVAL", "Min1"),
     "EMA_FAST": int(os.getenv("EMA_FAST", "9")),
     "EMA_SLOW": int(os.getenv("EMA_SLOW", "21")),
@@ -29,5 +32,5 @@ CONFIG = {
     "MAX_DAILY_PROFIT_PCT": float(os.getenv("MAX_DAILY_PROFIT_PCT", "5.0")),
 
     "MAX_POSITIONS": int(os.getenv("MAX_POSITIONS", "1")),
-    "ZERO_FEE_PAIRS": [p.strip() for p in os.getenv("ZERO_FEE_PAIRS", "").split(",") if p.strip()],
+    "ZERO_FEE_PAIRS": ZERO_FEE_PAIRS,
 }

--- a/tests/test_config_symbol.py
+++ b/tests/test_config_symbol.py
@@ -1,0 +1,13 @@
+import importlib
+import scalp.bot_config as bc
+
+
+def test_symbol_defaults_to_zero_fee_pair(monkeypatch):
+    monkeypatch.delenv("SYMBOL", raising=False)
+    monkeypatch.setenv("ZERO_FEE_PAIRS", "ETH_USDT,BTC_USDT")
+    importlib.reload(bc)
+    try:
+        assert bc.CONFIG["SYMBOL"] == "ETH_USDT"
+    finally:
+        monkeypatch.delenv("ZERO_FEE_PAIRS", raising=False)
+        importlib.reload(bc)

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -12,15 +12,17 @@ def test_send_selected_pairs(monkeypatch):
     monkeypatch.setattr(
         bot,
         "select_top_pairs",
-        lambda client, top_n=20: [
-            {"symbol": "WIFUSDT"},
-            {"symbol": "WIFUSDT"},
-            {"symbol": "BTCUSDT"},
+        lambda client, top_n=60: [
+            {"symbol": "WIFUSDT", "volume": 10},
+            {"symbol": "WIFUSDT", "volume": 9},
+            {"symbol": "BTCUSD", "volume": 8},
+            {"symbol": "BTCUSDT", "volume": 7},
+            {"symbol": "ETHUSDT", "volume": 6},
         ],
     )
 
     bot.send_selected_pairs(object(), top_n=3)
 
     assert sent["event"] == "pair_list"
-    assert sent["payload"]["pairs"] == "WIF, BTC"
+    assert sent["payload"]["pairs"] == "WIF, BTC, ETH"
 


### PR DESCRIPTION
## Summary
- only log missing environment variables during startup
- remove USD/USDT duplicates when sending top pairs
- default trading symbol comes from the first zero-fee pair when SYMBOL is unset
- document symbol default and add test coverage

## Testing
- `pytest tests/test_config_symbol.py tests/test_pairs.py`
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2f0def8ec832783b4124d8987d5df