### PR TITLE
feat: add break-even stop helper

### DIFF
--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -87,6 +87,34 @@ def trailing_stop(side: str, current_price: float, atr: float, sl: float, *, mul
     return min(sl, new_sl)
 
 
+def break_even_stop(
+    side: str,
+    entry_price: float,
+    current_price: float,
+    atr: float,
+    sl: float,
+    *,
+    mult: float = 1.0,
+) -> float:
+    """Move stop loss to break-even after a favourable move.
+
+    Once price advances ``mult`` times the ``atr`` from ``entry_price`` the
+    original stop loss ``sl`` is tightened to the entry.  This helps lock in
+    profits while still giving the trade room to develop.
+    """
+
+    side = side.lower()
+    if side == "long":
+        if current_price - entry_price >= mult * atr:
+            return max(sl, entry_price)
+        return sl
+    if side == "short":
+        if entry_price - current_price >= mult * atr:
+            return min(sl, entry_price)
+        return sl
+    raise ValueError("side must be 'long' or 'short'")
+
+
 def should_scale_in(
     entry_price: float,
     current_price: float,

--- a/tests/test_break_even_stop.py
+++ b/tests/test_break_even_stop.py
@@ -1,0 +1,15 @@
+from scalp.trade_utils import break_even_stop
+
+
+def test_break_even_stop_long() -> None:
+    sl = break_even_stop("long", entry_price=100, current_price=110, atr=5, sl=95)
+    assert sl == 100
+    sl = break_even_stop("long", entry_price=100, current_price=102, atr=5, sl=95)
+    assert sl == 95
+
+
+def test_break_even_stop_short() -> None:
+    sl = break_even_stop("short", entry_price=100, current_price=90, atr=5, sl=105)
+    assert sl == 100
+    sl = break_even_stop("short", entry_price=100, current_price=97, atr=5, sl=105)
+    assert sl == 105

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,10 +1,12 @@
 from scalp import RiskManager
-main
+
+
 def test_kill_switch_triggered() -> None:
     rm = RiskManager(max_daily_loss_pct=2.0, max_positions=1, risk_pct=0.01)
     rm.record_trade(-1.0)
     rm.record_trade(-1.5)
     assert rm.kill_switch is True
+
 
 def test_profit_kill_switch_triggered() -> None:
     rm = RiskManager(


### PR DESCRIPTION
## Summary
- add `break_even_stop` helper to tighten stops once price moves in favor
- test break-even stop behavior for long and short trades
- fix risk manager tests to run cleanly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a35531f15c8327a210ccd6c95d4b02