### PR TITLE
Fix Telegram positions list when PnL is zero

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -176,11 +176,13 @@ class TelegramBot:
                 base = self._base_symbol(symbol)
                 side = p.get("side")
                 vol = p.get("vol")
-                pnl = p.get("pnl_usd") or p.get("pnl")
+                pnl = p.get("pnl_usd")
+                if pnl is None:
+                    pnl = p.get("pnl")
                 pnl_pct = p.get("pnl_pct")
                 line = f"{base} {side} {vol}"
                 if pnl is not None and pnl_pct is not None:
-                    line += f"\nPnL: {pnl}€ ({pnl_pct}%)"
+                    line += f"\nPnL: {pnl} USDT ({pnl_pct}%)"
                 lines.append(line)
             if not lines:
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -55,6 +55,27 @@ def test_handle_positions():
     assert "PnL" in resp
 
 
+def test_handle_positions_zero_pnl():
+    bot = make_bot()
+
+    def zero_positions():
+        return {
+            "data": [
+                {
+                    "symbol": "BTC_USDT",
+                    "side": "long",
+                    "vol": 1,
+                    "pnl_usd": 0.0,
+                    "pnl_pct": 0.0,
+                }
+            ]
+        }
+
+    bot.client.get_positions = zero_positions
+    resp, _ = bot.handle_callback("positions", 0.0)
+    assert "PnL: 0.0 USDT" in resp
+
+
 
 def test_handle_pnl():
     bot = make_bot()


### PR DESCRIPTION
## Summary
- ensure Telegram bot keeps positions PnL when value is 0
- show PnL in USDT
- test positions listing with zero PnL

## Testing
- `pytest tests/test_telegram_bot.py::test_handle_positions -q`
- `pytest tests/test_telegram_bot.py::test_handle_positions_zero_pnl -q`
- `pytest -q` *(fails: NameError: name 'main' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a355dafe808327bd84ee6a0fcfef15