### PR TITLE
docs: documenter la stratégie de trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Le terminal reste silencieux au démarrage sauf en cas d'absence de variables cr
 
 Lors du démarrage, deux notifications Telegram sont émises : la première affiche « Bot démarré » avec un logo, la seconde « Listing : » suivi des 20 paires sélectionnées.
 
+## Stratégie
+
+Le bot met en œuvre une stratégie de scalping combinant plusieurs indicateurs techniques :
+
+- croisement des EMA 20/50 pour les signaux d’entrée ;
+- filtre de tendance via la MACD et une EMA longue configurable ;
+- confirmation par la position du prix par rapport au VWAP et par l’OBV ou un pic de volume ;
+- validation multi‑unités de temps (RSI 15 min, pente de l’EMA 1 h) ;
+- seuils dynamiques de stop‑loss et take‑profit calculés à partir de l’ATR, avec dimensionnement de position basé sur le risque.
+
+Une description détaillée des règles est disponible dans `STRATEGY.md`.
+
 ## Version
 
 La version du bot est stockée dans le fichier `scalp/VERSION` et exposée dans

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,34 @@
+# Stratégie de trading
+
+Ce document décrit la logique de trading utilisée par le bot **Scalp**. Elle vise un scalping court terme sur les futures USDT‑M de MEXC.
+
+## Sélection des paires
+
+1. `scan_pairs` récupère les tickers MEXC et filtre ceux qui sont à **frais nuls**, possèdent un volume quotidien suffisant et un spread réduit.
+2. `select_active_pairs` affine la liste en conservant les paires présentant le plus de **momentum** :
+   - croisement entre EMA20 et EMA50 ;
+   - ATR élevé pour privilégier les actifs volatils.
+
+## Génération du signal
+
+`generate_signal` produit un signal d’entrée long ou court lorsque les conditions suivantes sont réunies :
+
+- prix au‑dessus ou en dessous du **VWAP** et des EMA20/50 selon la direction recherchée ;
+- **RSI(14)** traversant les niveaux 40/60 avec confirmation d’un **RSI 15 min** et de la pente de l’**EMA 1 h** ;
+- **MACD** alignée avec la tendance et **EMA** longue en filtrage global ;
+- hausse d’**OBV** ou volume supérieur à la moyenne ;
+- cassure du dernier **swing high/low** ;
+- éventuel filtre d’**order book imbalance** et de ratio de ticks.
+
+Les distances de stop et de take profit sont calculées à partir de l’**ATR**, ce qui permet également de dimensionner la taille de position via `calc_position_size`.
+
+## Gestion du risque
+
+La classe `RiskManager` applique plusieurs garde‑fous :
+
+- limite de perte quotidienne (`max_daily_loss_pct`) et optionnellement de gain (`max_daily_profit_pct`) déclenchant un *kill switch* ;
+- suivi des séries de gains/pertes pour ajuster le pourcentage de risque par trade ;
+- pause forcée en cas de pertes consécutives prolongées ;
+- contrôle du nombre maximal de positions ouvertes.
+
+Ces règles combinées visent à protéger le capital tout en conservant une exposition opportuniste au marché.


### PR DESCRIPTION
## Summary
- préciser la stratégie de scalping dans le README
- ajouter un document détaillant les règles de la stratégie

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a356bcbe9c8327b85def2fefa75ec9