### PR TITLE
feat: enrich signals with confluence scoring

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,5 @@
+"""Indicator computation helpers."""
+
+from .indicators import compute_all
+
+__all__ = ["compute_all"]

--- a/data/indicators.py
+++ b/data/indicators.py
@@ -1,0 +1,88 @@
+import pandas as pd
+
+__all__ = ["compute_all"]
+
+def compute_all(
+    df: pd.DataFrame,
+    *,
+    ema_fast: int = 20,
+    ema_slow: int = 50,
+    rsi_period: int = 14,
+    macd_fast: int = 12,
+    macd_slow: int = 26,
+    macd_signal: int = 9,
+    atr_period: int = 14,
+    swing_lookback: int = 5,
+) -> pd.DataFrame:
+    """Compute common indicators and return enriched DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing at least ``open``, ``high``, ``low``, ``close`` and
+        ``volume`` columns ordered chronologically.
+
+    Returns
+    -------
+    pd.DataFrame
+        New DataFrame with additional indicator columns.
+    """
+
+    if df.empty:
+        return df.copy()
+
+    df = df.copy()
+
+    # --- VWAP ---------------------------------------------------------------
+    typical = (df["high"] + df["low"] + df["close"]) / 3.0
+    vwap = (typical * df["volume"]).cumsum() / df["volume"].cumsum()
+    df["vwap"] = vwap
+
+    # --- EMAs ---------------------------------------------------------------
+    df["ema20"] = df["close"].ewm(span=ema_fast, adjust=False).mean()
+    df["ema50"] = df["close"].ewm(span=ema_slow, adjust=False).mean()
+
+    # --- RSI ----------------------------------------------------------------
+    delta = df["close"].diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = -delta.where(delta < 0, 0.0)
+    avg_gain = gain.rolling(rsi_period).mean()
+    avg_loss = loss.rolling(rsi_period).mean()
+    rs = avg_gain / avg_loss
+    rsi = 100 - (100 / (1 + rs))
+    df["rsi"] = rsi.fillna(50.0)
+
+    # --- MACD ---------------------------------------------------------------
+    ema_fast_series = df["close"].ewm(span=macd_fast, adjust=False).mean()
+    ema_slow_series = df["close"].ewm(span=macd_slow, adjust=False).mean()
+    macd = ema_fast_series - ema_slow_series
+    signal = macd.ewm(span=macd_signal, adjust=False).mean()
+    df["macd"] = macd
+    df["macd_signal"] = signal
+    df["macd_hist"] = macd - signal
+
+    # --- OBV ----------------------------------------------------------------
+    obv = [0.0]
+    closes = df["close"].tolist()
+    vols = df["volume"].tolist()
+    for i in range(1, len(df)):
+        if closes[i] > closes[i - 1]:
+            obv.append(obv[-1] + vols[i])
+        elif closes[i] < closes[i - 1]:
+            obv.append(obv[-1] - vols[i])
+        else:
+            obv.append(obv[-1])
+    df["obv"] = obv
+
+    # --- ATR ----------------------------------------------------------------
+    high_low = df["high"] - df["low"]
+    high_close = (df["high"] - df["close"].shift()).abs()
+    low_close = (df["low"] - df["close"].shift()).abs()
+    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+    df["atr"] = tr.rolling(atr_period).mean()
+
+    # --- Swing highs/lows ---------------------------------------------------
+    df["swing_high"] = df["high"].rolling(window=swing_lookback).max()
+    df["swing_low"] = df["low"].rolling(window=swing_lookback).min()
+
+    return df

--- a/signals/__init__.py
+++ b/signals/__init__.py
@@ -1,0 +1,5 @@
+"""Signal generation utilities."""
+
+from .generator import generate_signal
+
+__all__ = ["generate_signal"]

--- a/signals/generator.py
+++ b/signals/generator.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from data.indicators import compute_all
+
+__all__ = ["generate_signal"]
+
+
+def _quality_from_score(score: float) -> str:
+    if score >= 0.8:
+        return "A"
+    if score >= 0.5:
+        return "B"
+    return "C"
+
+
+def generate_signal(
+    df: pd.DataFrame,
+    *,
+    trend_tf: Optional[pd.DataFrame] = None,
+    confirm_tf: Optional[pd.DataFrame] = None,
+    atr_mult: float = 1.0,
+    trailing: bool = False,
+    **_: Any,
+) -> Optional[Dict[str, Any]]:
+    """Generate a trading signal with confluence scoring.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        Primary timeframe OHLCV data.
+    trend_tf: pd.DataFrame, optional
+        Higher timeframe used for trend filtering.
+    confirm_tf: pd.DataFrame, optional
+        Lower timeframe used for confirmation.
+    atr_mult: float, optional
+        Multiplier applied to ATR for stop/target calculation.
+    trailing: bool, optional
+        When ``True`` include a ``trail`` distance (ATR * ``atr_mult``).
+
+    Returns
+    -------
+    dict | None
+        Dictionary describing the signal or ``None`` if no trade setup exists.
+    """
+
+    if df is None or len(df) < 2:
+        return None
+
+    df = compute_all(df)
+    last = df.iloc[-1]
+
+    conditions: List[bool] = []
+    reasons: List[str] = []
+    direction: Optional[str] = None
+
+    # --- Basic trend via EMAs ----------------------------------------------
+    if last["close"] > last["ema20"] > last["ema50"]:
+        direction = "long"
+        reasons.append("price_above_ema")
+        conditions.append(True)
+    elif last["close"] < last["ema20"] < last["ema50"]:
+        direction = "short"
+        reasons.append("price_below_ema")
+        conditions.append(True)
+    else:
+        conditions.append(False)
+        return None
+
+    # --- RSI ---------------------------------------------------------------
+    if direction == "long":
+        cond = last["rsi"] > 55
+        if cond:
+            reasons.append("rsi_bullish")
+        conditions.append(cond)
+    else:
+        cond = last["rsi"] < 45
+        if cond:
+            reasons.append("rsi_bearish")
+        conditions.append(cond)
+
+    # --- MACD --------------------------------------------------------------
+    if direction == "long":
+        cond = last["macd"] > last["macd_signal"]
+        if cond:
+            reasons.append("macd_bullish")
+        conditions.append(cond)
+    else:
+        cond = last["macd"] < last["macd_signal"]
+        if cond:
+            reasons.append("macd_bearish")
+        conditions.append(cond)
+
+    # --- OBV momentum ------------------------------------------------------
+    if len(df) >= 2:
+        obv_up = df["obv"].iloc[-1] > df["obv"].iloc[-2]
+        if obv_up:
+            reasons.append("obv_trending")
+        conditions.append(obv_up)
+
+    # --- Trend timeframe filter -------------------------------------------
+    if trend_tf is not None and len(trend_tf) >= 2:
+        tdf = compute_all(trend_tf)
+        ema50 = tdf["ema50"]
+        slope = ema50.iloc[-1] - ema50.iloc[-2]
+        if direction == "long":
+            cond = slope > 0
+            if cond:
+                reasons.append("trend_up")
+            conditions.append(cond)
+        else:
+            cond = slope < 0
+            if cond:
+                reasons.append("trend_down")
+            conditions.append(cond)
+
+    # --- Confirmation timeframe filter ------------------------------------
+    if confirm_tf is not None and len(confirm_tf) > 0:
+        cdf = compute_all(confirm_tf)
+        rsi = cdf["rsi"].iloc[-1]
+        if direction == "long":
+            cond = rsi > 50
+            if cond:
+                reasons.append("confirm_rsi_bullish")
+            conditions.append(cond)
+        else:
+            cond = rsi < 50
+            if cond:
+                reasons.append("confirm_rsi_bearish")
+            conditions.append(cond)
+
+    score = (
+        sum(1 for c in conditions if c) / len(conditions) if conditions else 0.0
+    )
+    quality = _quality_from_score(score)
+
+    atr = last.get("atr")
+    if pd.isna(atr) or atr == 0:
+        return None
+
+    entry = float(last["close"])
+    if direction == "long":
+        sl = entry - atr * atr_mult
+        tp = entry + atr * atr_mult * 2
+    else:
+        sl = entry + atr * atr_mult
+        tp = entry - atr * atr_mult * 2
+
+    result: Dict[str, Any] = {
+        "direction": direction,
+        "entry": entry,
+        "sl": sl,
+        "tp": tp,
+        "score": round(score, 3),
+        "reasons": reasons,
+        "quality": quality,
+    }
+
+    if trailing:
+        result["trail"] = atr * atr_mult
+
+    return result


### PR DESCRIPTION
## Summary
- add compute_all helper to build VWAP, EMAs, RSI, MACD, OBV, ATR and swing levels
- extend signal generator with multi-timeframe support, confluence scoring and ATR based risk targets

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35c7fceac8327b3c13602f8404fcf