### PR TITLE
feat: add volatility and momentum filters for pair selection

### DIFF
--- a/scalp/selection/__init__.py
+++ b/scalp/selection/__init__.py
@@ -1,0 +1,19 @@
+"""Pair selection helpers for the Scalp bot.
+
+This package exposes two utilities used during the preparation phase of the
+trading strategy:
+
+``scan_pairs``
+    Performs the first level market scan by filtering pairs based on volume,
+    spread and hourly volatility.
+
+``select_active_pairs``
+    Refines a list of pairs by keeping only those showing an EMA20/EMA50
+    crossover and a sufficiently high ATR.
+"""
+
+from .scanner import scan_pairs
+from .momentum import select_active_pairs
+
+__all__ = ["scan_pairs", "select_active_pairs"]
+

--- a/scalp/selection/momentum.py
+++ b/scalp/selection/momentum.py
@@ -1,0 +1,98 @@
+"""Utilities to select pairs exhibiting strong momentum."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+from ..metrics import calc_atr
+
+
+def ema(series: Sequence[float], window: int) -> List[float]:
+    """Simple exponential moving average implementation."""
+
+    if window <= 1 or not series:
+        return list(series)
+    k = 2.0 / (window + 1.0)
+    out: List[float] = [float(series[0])]
+    prev = out[0]
+    for x in series[1:]:
+        prev = float(x) * k + prev * (1.0 - k)
+        out.append(prev)
+    return out
+
+
+def cross(last_fast: float, last_slow: float, prev_fast: float, prev_slow: float) -> int:
+    """Return 1 if a bullish cross occurred, -1 for bearish, 0 otherwise."""
+
+    if prev_fast <= prev_slow and last_fast > last_slow:
+        return 1
+    if prev_fast >= prev_slow and last_fast < last_slow:
+        return -1
+    return 0
+
+
+def _quantile(values: Sequence[float], q: float) -> float:
+    """Return the *q* quantile of *values* (0 <= q <= 1)."""
+
+    if not values:
+        return 0.0
+    q = min(max(q, 0.0), 1.0)
+    vals = sorted(values)
+    idx = int((len(vals) - 1) * q)
+    return vals[idx]
+
+
+def select_active_pairs(
+    client: Any,
+    pairs: Sequence[Dict[str, Any]],
+    *,
+    interval: str = "Min5",
+    ema_fast: int = 20,
+    ema_slow: int = 50,
+    atr_period: int = 14,
+    atr_quantile: float = 0.5,
+    top_n: int = 5,
+) -> List[Dict[str, Any]]:
+    """Return pairs with an EMA crossover and high ATR.
+
+    Only pairs where ``EMA20`` crosses ``EMA50`` on the latest candle are kept.
+    Among those candidates, the Average True Range is computed and only pairs
+    whose ATR is above the provided quantile are returned.  The resulting
+    dictionaries include an ``atr`` key for convenience.
+    """
+
+    candidates: List[Dict[str, Any]] = []
+    atrs: List[float] = []
+
+    for info in pairs:
+        sym = info.get("symbol")
+        if not sym:
+            continue
+        k = client.get_kline(sym, interval=interval)
+        kdata = k.get("data") if isinstance(k, dict) else {}
+        closes = kdata.get("close", [])
+        highs = kdata.get("high", [])
+        lows = kdata.get("low", [])
+        if len(closes) < max(ema_slow, atr_period) + 2:
+            continue
+        efast = ema(closes, ema_fast)
+        eslow = ema(closes, ema_slow)
+        if cross(efast[-1], eslow[-1], efast[-2], eslow[-2]) == 0:
+            continue
+        atr_val = calc_atr(highs, lows, closes, atr_period)
+        row = dict(info)
+        row["atr"] = atr_val
+        candidates.append(row)
+        atrs.append(atr_val)
+
+    if not candidates:
+        return []
+
+    threshold = _quantile(atrs, atr_quantile)
+    selected = [row for row in candidates if row["atr"] >= threshold]
+    selected.sort(key=lambda r: r["atr"], reverse=True)
+    return selected[:top_n]
+
+
+__all__ = ["select_active_pairs"]
+

--- a/scalp/selection/scanner.py
+++ b/scalp/selection/scanner.py
@@ -1,0 +1,85 @@
+"""Utilities for scanning tradable pairs on the exchange."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+
+def scan_pairs(
+    client: Any,
+    *,
+    zero_fee_pairs: Sequence[str],
+    volume_min: float = 5_000_000,
+    max_spread_bps: float = 5.0,
+    min_hourly_vol: float = 0.0,
+    top_n: int = 20,
+) -> List[Dict[str, Any]]:
+    """Return pairs satisfying basic liquidity and volatility filters.
+
+    Parameters
+    ----------
+    client: Any
+        Client instance exposing ``get_ticker`` and ``get_kline`` methods.
+    zero_fee_pairs: Sequence[str]
+        Symbols eligible for zero fees on the exchange.
+    volume_min: float, optional
+        Minimum 24h volume required to keep a pair.
+    max_spread_bps: float, optional
+        Maximum allowed bid/ask spread expressed in basis points.
+    min_hourly_vol: float, optional
+        Minimum volatility over the last hour expressed as ``(high - low) /
+        close``.  When set to ``0`` the filter is disabled.
+    top_n: int, optional
+        Limit the number of returned pairs.
+    """
+
+    tick = client.get_ticker()
+    data = tick.get("data") if isinstance(tick, dict) else []
+    if not isinstance(data, list):
+        data = [data]
+
+    zero_fee = set(zero_fee_pairs)
+    eligible: List[Dict[str, Any]] = []
+
+    for row in data:
+        sym = row.get("symbol")
+        if not sym or sym not in zero_fee:
+            continue
+        try:
+            vol = float(row.get("volume", 0))
+            bid = float(row.get("bidPrice", 0))
+            ask = float(row.get("askPrice", 0))
+        except (TypeError, ValueError):
+            continue
+        if vol < volume_min or bid <= 0 or ask <= 0:
+            continue
+        spread_bps = (ask - bid) / ((ask + bid) / 2.0) * 10_000
+        if spread_bps >= max_spread_bps:
+            continue
+
+        if min_hourly_vol > 0:
+            k = client.get_kline(sym, interval="Min60")
+            kdata = k.get("data") if isinstance(k, dict) else {}
+            highs = kdata.get("high", [])
+            lows = kdata.get("low", [])
+            closes = kdata.get("close", [])
+            if not highs or not lows or not closes:
+                continue
+            try:
+                h = float(highs[-1])
+                l = float(lows[-1])
+                c = float(closes[-1])
+            except (TypeError, ValueError):
+                continue
+            hourly_vol = (h - l) / c if c else 0.0
+            if hourly_vol < min_hourly_vol:
+                continue
+
+        eligible.append(row)
+
+    eligible.sort(key=lambda r: float(r.get("volume", 0)), reverse=True)
+    return eligible[:top_n]
+
+
+__all__ = ["scan_pairs"]
+


### PR DESCRIPTION
## Summary
- add hourly volatility check to pair scanning
- support EMA crossover with ATR quantile filtering when selecting active pairs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a35cc7bf8c832791277848bb1add8f