### PR TITLE
Add CLI tool for optimisation, walk-forward, and live modes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,111 @@
+"""Command line utilities for the Scalp project.
+
+This module exposes a small command line interface used throughout the
+project.  The actual trading logic lives in other modules, however the CLI is
+responsible for parsing parameters and dispatching the appropriate routines.
+
+The implementation intentionally keeps the invoked functions minimal so that
+tests can patch them easily.  In a real deployment these functions would
+perform optimisation, walk‑forward analysis or run the live pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Iterable, List
+
+
+# ---------------------------------------------------------------------------
+# Placeholder implementations
+# ---------------------------------------------------------------------------
+
+
+def run_parallel_optimization(pairs: List[str], timeframe: str, jobs: int) -> None:
+    """Run a parallel parameter optimisation.
+
+    The real project dispatches a potentially heavy optimisation routine.  The
+    function is kept trivial so unit tests can verify that the CLI wiring works
+    without actually performing the optimisation.
+    """
+
+    print(f"Optimising {pairs} on {timeframe} with {jobs} jobs")
+
+
+def run_walkforward_analysis(
+    pair: str, timeframe: str, splits: int, train_ratio: float
+) -> None:
+    """Execute a walk-forward analysis."""
+
+    print(
+        f"Walk-forward on {pair} ({timeframe}), splits={splits}, train_ratio={train_ratio}"
+    )
+
+
+async def run_live_pipeline(pairs: List[str], tfs: Iterable[str]) -> None:
+    """Run the live trading pipeline."""
+
+    print(f"Running live pipeline for pairs={pairs} on tfs={list(tfs)}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the top-level argument parser."""
+
+    parser = argparse.ArgumentParser(description="Scalp command line tools")
+    sub = parser.add_subparsers(dest="command")
+
+    # --- ``opt`` command -------------------------------------------------
+    opt_p = sub.add_parser("opt", help="run optimisation in parallel")
+    opt_p.add_argument("--pairs", nargs="+", required=True, help="trading pairs")
+    opt_p.add_argument("--tf", required=True, help="timeframe")
+    opt_p.add_argument("--jobs", type=int, default=1, help="number of workers")
+    opt_p.set_defaults(
+        func=lambda a: run_parallel_optimization(a.pairs, a.tf, a.jobs)
+    )
+
+    # --- ``walkforward`` command ----------------------------------------
+    wf_p = sub.add_parser("walkforward", help="perform walk-forward analysis")
+    wf_p.add_argument("--pair", required=True, help="trading pair")
+    wf_p.add_argument("--tf", required=True, help="timeframe")
+    wf_p.add_argument("--splits", type=int, default=1, help="number of splits")
+    wf_p.add_argument(
+        "--train-ratio",
+        type=float,
+        default=0.7,
+        help="portion of data used for training",
+    )
+    wf_p.set_defaults(
+        func=lambda a: run_walkforward_analysis(
+            a.pair, a.tf, a.splits, a.train_ratio
+        )
+    )
+
+    # --- ``live`` command -----------------------------------------------
+    live_p = sub.add_parser("live", help="run the live async pipeline")
+    live_p.add_argument("--pairs", nargs="+", required=True, help="trading pairs")
+    live_p.add_argument("--tfs", nargs="+", required=True, help="timeframes")
+    live_p.set_defaults(func=lambda a: asyncio.run(run_live_pipeline(a.pairs, a.tfs)))
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Entry point used by tests and ``if __name__ == '__main__'`` block."""
+
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 0
+    result = args.func(args)
+    return 0 if result is None else int(result)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,57 @@
+"""Tests for the command line interface defined in :mod:`cli`."""
+
+from __future__ import annotations
+
+import cli
+
+
+def test_opt_invokes_parallel_optimization(monkeypatch):
+    """The ``opt`` command should call ``run_parallel_optimization``."""
+
+    called = {}
+
+    def fake_run(pairs, tf, jobs):  # pragma: no cover - executed via CLI
+        called["args"] = (pairs, tf, jobs)
+
+    monkeypatch.setattr(cli, "run_parallel_optimization", fake_run)
+    cli.main(["opt", "--pairs", "BTCUSDT", "ETHUSDT", "--tf", "1h", "--jobs", "4"])
+    assert called["args"] == (["BTCUSDT", "ETHUSDT"], "1h", 4)
+
+
+def test_walkforward_invokes_analysis(monkeypatch):
+    """The ``walkforward`` command calls ``run_walkforward_analysis``."""
+
+    called = {}
+
+    def fake_run(pair, tf, splits, train_ratio):  # pragma: no cover
+        called["args"] = (pair, tf, splits, train_ratio)
+
+    monkeypatch.setattr(cli, "run_walkforward_analysis", fake_run)
+    cli.main(
+        [
+            "walkforward",
+            "--pair",
+            "BTCUSDT",
+            "--tf",
+            "1m",
+            "--splits",
+            "3",
+            "--train-ratio",
+            "0.8",
+        ]
+    )
+    assert called["args"] == ("BTCUSDT", "1m", 3, 0.8)
+
+
+def test_live_invokes_async_pipeline(monkeypatch):
+    """The ``live`` command must execute the async pipeline via ``asyncio.run``."""
+
+    called = {}
+
+    async def fake_live(pairs, tfs):  # pragma: no cover - executed asynchronously
+        called["args"] = (pairs, list(tfs))
+
+    monkeypatch.setattr(cli, "run_live_pipeline", fake_live)
+    cli.main(["live", "--pairs", "BTCUSDT", "ETHUSDT", "--tfs", "1m", "1h"])
+    assert called["args"] == (["BTCUSDT", "ETHUSDT"], ["1m", "1h"])
+


### PR DESCRIPTION
## Summary
- Introduce `cli.py` exposing `opt`, `walkforward`, and `live` commands
- Support asynchronous live pipeline entry point
- Add tests to verify CLI dispatches to underlying routines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35d7f72108327bd7b278df7efeb04