### PR TITLE
feat: add telegram reset risk button

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -140,7 +140,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         os.path.join(cfg["LOG_DIR"], "trades.sqlite"),
     )
 
-    tg_bot = init_telegram_bot(client, cfg)
+    tg_bot = init_telegram_bot(client, cfg, risk_mgr)
 
     symbol = cfg["SYMBOL"]
     interval = cfg["INTERVAL"]

--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -34,6 +34,7 @@ class TelegramBot:
         chat_id: str,
         client: Any,
         config: Dict[str, Any],
+        risk_mgr: Any,
         *,
         requests_module: Any = requests,
     ) -> None:
@@ -41,6 +42,7 @@ class TelegramBot:
         self.chat_id = str(chat_id)
         self.client = client
         self.config = config
+        self.risk_mgr = risk_mgr
         self.requests = requests_module
         self.last_update_id: Optional[int] = None
 
@@ -50,6 +52,7 @@ class TelegramBot:
             [{"text": "Positions", "callback_data": "positions"}],
             [{"text": "PnL session", "callback_data": "pnl"}],
             [{"text": "Risque", "callback_data": "risk"}],
+            [{"text": "Reset Risk", "callback_data": "reset_risk"}],
 
             [{"text": "Stop", "callback_data": "stop"}],
 
@@ -202,6 +205,13 @@ class TelegramBot:
                 pass
             return "Niveau de risque inchangé", self.main_keyboard
 
+        if data == "reset_risk":
+            try:
+                self.risk_mgr.reset_day()
+                return "RiskManager réinitialisé", self.main_keyboard
+            except Exception:
+                return "Erreur reset RiskManager", self.main_keyboard
+
         if data == "stop":
             return "Choisissez la position à fermer:", self._build_stop_keyboard()
         if data == "stop_all":
@@ -223,9 +233,9 @@ class TelegramBot:
         return None, None
 
 
-def init_telegram_bot(client: Any, config: Dict[str, Any]) -> Optional[TelegramBot]:
+def init_telegram_bot(client: Any, config: Dict[str, Any], risk_mgr: Any) -> Optional[TelegramBot]:
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if token and chat_id:
-        return TelegramBot(token, chat_id, client, config)
+        return TelegramBot(token, chat_id, client, config, risk_mgr)
     return None

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -32,11 +32,20 @@ class DummyClient:
 
 
 
+class DummyRiskMgr:
+
+    def __init__(self):
+        self.reset_called = False
+
+    def reset_day(self):
+        self.reset_called = True
+
+
 def make_bot(config=None):
     cfg = {"RISK_LEVEL": 2}
     if config:
         cfg.update(config)
-    return TelegramBot("t", "1", DummyClient(), cfg)
+    return TelegramBot("t", "1", DummyClient(), cfg, DummyRiskMgr())
 
 
 def test_handle_balance():
@@ -118,4 +127,12 @@ def test_handle_unknown():
     resp, kb = bot.handle_callback("foobar", 0.0)
     assert resp is None
     assert kb is None
+
+
+def test_reset_risk_manager():
+    bot = make_bot()
+    resp, kb = bot.handle_callback("reset_risk", 0.0)
+    assert "réinitialisé" in resp.lower()
+    assert bot.risk_mgr.reset_called is True
+    assert kb == bot.main_keyboard
 


### PR DESCRIPTION
## Summary
- allow TelegramBot to reset RiskManager via new button
- adapt bot initialization and tests for risk reset

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a367fec83c8327807e324510ca7816