### PR TITLE
docs: clarify strategy principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,20 @@ Lors du démarrage, deux notifications Telegram sont émises : la première affi
 
 ## Stratégie
 
-Le bot met en œuvre une stratégie de scalping combinant plusieurs indicateurs techniques :
+Scalp cherche à capter de courts mouvements de tendance tout en coupant
+rapidement les pertes.
 
-- croisement des EMA 20/50 pour les signaux d’entrée ;
-- filtre de tendance via la MACD et une EMA longue configurable ;
-- confirmation par la position du prix par rapport au VWAP et par l’OBV ou un pic de volume ;
-- validation multi‑unités de temps (RSI 15 min, pente de l’EMA 1 h) ;
-- seuils dynamiques de stop‑loss et take‑profit calculés à partir de l’ATR, avec dimensionnement de position basé sur le risque.
+Principes généraux :
 
-Une description détaillée des règles est disponible dans `STRATEGY.md`.
+- sélection de paires liquides à frais nuls et au fort momentum ;
+- trade uniquement dans le sens de la tendance dominante (MACD + EMA longue) ;
+- confirmation multi‑indicateurs (VWAP, volume/OBV, RSI multi‑UT) ;
+- stop‑loss et take‑profit dynamiques basés sur l’ATR avec taille de position
+  calculée selon le risque ;
+- limites quotidiennes pour protéger le capital.
+
+Les règles détaillées et l’algorithme complet sont décrits dans
+`STRATEGY.md`.
 
 ## Version
 

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -2,6 +2,14 @@
 
 Ce document décrit la logique de trading utilisée par le bot **Scalp**. Elle vise un scalping court terme sur les futures USDT‑M de MEXC.
 
+## Principes généraux
+
+- ne traiter que des actifs liquides à fort momentum et à frais nuls ;
+- suivre la tendance dominante et éviter les marchés plats ;
+- utiliser des confirmations multi‑unités de temps pour limiter les faux signaux ;
+- dimensionner chaque position selon un pourcentage fixe du capital ;
+- couper rapidement les pertes et laisser courir les gains via un suivi dynamique.
+
 ## Sélection des paires
 
 1. `scan_pairs` récupère les tickers MEXC et filtre ceux qui sont à **frais nuls**, possèdent un volume quotidien suffisant et un spread réduit.


### PR DESCRIPTION
## Summary
- refine README strategy section with concise principles and link to detailed doc
- add general trading principles section to STRATEGY.md

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36e10fffc8327966a3a3a211611a8