### PR TITLE
Add reset-all option for Telegram bot

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -53,7 +53,7 @@ class TelegramBot:
             [{"text": "Positions", "callback_data": "positions"}],
             [{"text": "PnL session", "callback_data": "pnl"}],
             [{"text": "Risque", "callback_data": "risk"}],
-            [{"text": "Reset Risk", "callback_data": "reset_risk"}],
+            [{"text": "Reset All", "callback_data": "reset_all"}],
 
             [{"text": "Stop", "callback_data": "stop"}],
             [{"text": "Fermer Bot", "callback_data": "shutdown"}],
@@ -209,12 +209,13 @@ class TelegramBot:
                 return f"Niveau de risque réglé sur {lvl}", self.main_keyboard
             return "Niveau de risque inchangé", self.main_keyboard
 
-        if data == "reset_risk":
+        if data == "reset_all":
             try:
+                self.client.close_all_positions()
                 self.risk_mgr.reset_day()
-                return "RiskManager réinitialisé", self.main_keyboard
+                return "Positions et risque réinitialisés", self.main_keyboard
             except Exception:
-                return "Erreur reset RiskManager", self.main_keyboard
+                return "Erreur reset total", self.main_keyboard
 
         if data == "stop":
             return "Choisissez la position à fermer:", self._build_stop_keyboard()

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -129,11 +129,12 @@ def test_handle_unknown():
     assert kb is None
 
 
-def test_reset_risk_manager():
+def test_reset_all():
     bot = make_bot()
-    resp, kb = bot.handle_callback("reset_risk", 0.0)
-    assert "réinitialisé" in resp.lower()
+    resp, kb = bot.handle_callback("reset_all", 0.0)
+    assert "réinitialisés" in resp.lower()
     assert bot.risk_mgr.reset_called is True
+    assert bot.client.closed_all is True
     assert kb == bot.main_keyboard
 
 


### PR DESCRIPTION
## Summary
- Replace `Reset Risk` button with `Reset All` in Telegram bot
- Reset All closes all open positions and resets RiskManager
- Update tests for new reset-all behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a379b8c04c83279c5a669c05f52f25