### PR TITLE
Improve position sizing robustness for invalid market data

### DIFF
--- a/tests/test_compute_position_size.py
+++ b/tests/test_compute_position_size.py
@@ -29,3 +29,25 @@ def test_compute_position_size_symbol_not_found():
     with pytest.raises(ValueError):
         compute_position_size(contract_detail, equity_usdt=1000, price=500,
                                 risk_pct=0.01, leverage=10, symbol="BTC_USDT")
+
+
+def test_compute_position_size_invalid_price():
+    contract_detail = {
+        "data": [
+            {
+                "symbol": "BTC_USDT",
+                "contractSize": 0.01,
+                "volUnit": 1,
+                "minVol": 1,
+            }
+        ]
+    }
+    vol = compute_position_size(
+        contract_detail,
+        equity_usdt=1000,
+        price=0,
+        risk_pct=0.01,
+        leverage=10,
+        symbol="BTC_USDT",
+    )
+    assert vol == 0


### PR DESCRIPTION
## Summary
- validate price and contract metadata in compute_position_size to avoid zero-division and negative volumes
- cover non-positive price case with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f46069908327aaba33a6d1e4ac99