### PR TITLE
Fix Telegram trade closing

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -86,7 +86,10 @@ class TelegramBot:
             if not sym:
                 continue
             base = self._base_symbol(sym)
-            buttons.append([{"text": base, "callback_data": f"stop_{base}"}])
+            # Use the full symbol in the callback so we can properly
+            # identify the position to close.  Only the label shows the
+            # base asset to keep the interface concise.
+            buttons.append([{"text": base, "callback_data": f"stop_{sym}"}])
         buttons.append([{"text": "Tous", "callback_data": "stop_all"}])
         buttons.append([{"text": "Retour", "callback_data": "back"}])
         return buttons

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -126,11 +126,13 @@ def test_risk_menu():
 def test_stop_menu_and_actions():
     bot = make_bot()
     resp, kb = bot.handle_callback("stop", 0.0)
-    assert any(btn["callback_data"] == "stop_BTC" for row in kb for btn in row)
+    assert any(
+        btn["callback_data"] == "stop_BTC_USDT" for row in kb for btn in row
+    )
     assert any(btn["callback_data"] == "stop_all" for row in kb for btn in row)
-    resp, _ = bot.handle_callback("stop_BTC", 0.0)
+    resp, _ = bot.handle_callback("stop_BTC_USDT", 0.0)
     assert "fermée" in resp.lower()
-    assert bot.client.closed == ["BTC"]
+    assert bot.client.closed == ["BTC_USDT"]
     resp, _ = bot.handle_callback("stop_all", 0.0)
     assert bot.client.closed_all is True
 


### PR DESCRIPTION
## Summary
- fix Telegram bot position stop buttons to include full symbol
- adjust tests for new callback handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3f6356620832782526e946106a268