### PR TITLE
fix: include all pairs when no zero-fee configuration

### DIFF
--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -32,7 +32,10 @@ def filter_trade_pairs(
 
     for info in pairs:
         sym = info.get("symbol")
-        if not sym or sym not in zero_fee:
+        # Only enforce the zero-fee filter when a list is provided.  Previously,
+        # an empty configuration would discard every pair, resulting in an empty
+        # listing on Telegram.
+        if not sym or (zero_fee and sym not in zero_fee):
             continue
         try:
             vol = float(info.get("volume", 0))

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -28,3 +28,19 @@ def test_send_selected_pairs(monkeypatch):
     assert sent["payload"]["orange"] == "BTC"
     assert sent["payload"]["red"] == "DOGE"
 
+
+def test_filter_trade_pairs_no_zero_fee(monkeypatch):
+    class DummyClient:
+        def get_ticker(self):
+            return {
+                "data": [
+                    {"symbol": "BTCUSDT", "volume": 100, "bidPrice": 1, "askPrice": 1.0001},
+                    {"symbol": "ETHUSDT", "volume": 90, "bidPrice": 1, "askPrice": 1.0001},
+                ]
+            }
+
+    client = DummyClient()
+    # With no zero-fee pairs configured, the function should return all pairs
+    res = bot.filter_trade_pairs(client, volume_min=0, max_spread_bps=10, top_n=5)
+    assert [r["symbol"] for r in res] == ["BTCUSDT", "ETHUSDT"]
+


### PR DESCRIPTION
## Summary
- avoid filtering out all pairs when no zero-fee list provided
- add regression test for pair filtering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3f65b7c6083278711722713d9de5c