### PR TITLE
Handle stop trade without positions and improve error messages

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -261,23 +261,26 @@ class TelegramBot:
                 self.risk_mgr.reset_day()
                 return "Positions et risque réinitialisés", self.settings_keyboard
             except Exception:
-                return "Erreur reset total", self.settings_keyboard
+                return "Erreur lors du reset total", self.settings_keyboard
 
         if data == "stop":
+            pos = self.client.get_positions()
+            if not pos.get("data"):
+                return "Aucune crypto sélectionnée", self.settings_keyboard
             return "Choisissez la position à fermer:", self._build_stop_keyboard()
         if data == "stop_all":
             try:
                 self.client.close_all_positions()
                 return "Toutes les positions fermées", self.settings_keyboard
             except Exception:
-                return "Erreur fermeture positions", self.settings_keyboard
+                return "Erreur arrêt trade", self.settings_keyboard
         if data.startswith("stop_"):
             sym = data[5:]
             try:
                 self.client.close_position(sym)
                 return f"Position {sym} fermée", self.settings_keyboard
             except Exception:
-                return f"Erreur fermeture {sym}", self.settings_keyboard
+                return f"Erreur arrêt trade {sym}", self.settings_keyboard
 
         if data == "shutdown":
             self.stop_requested = True

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -193,3 +193,11 @@ def test_update_button(monkeypatch):
     assert "mise à jour" in resp.lower()
     assert kb == bot.main_keyboard
 
+
+def test_stop_no_positions():
+    bot = make_bot()
+    bot.client.get_positions = lambda: {"data": []}
+    resp, kb = bot.handle_callback("stop", 0.0)
+    assert "aucune crypto" in resp.lower()
+    assert kb == bot.settings_keyboard
+


### PR DESCRIPTION
## Summary
- Return a clear message when attempting to stop trades with no open positions
- Clarify French error messages for full resets and failed position closures
- Test stop action when there are no positions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3f92cc5508327a2e0918d48de7373