### PR TITLE
feat: refresh zero-fee pairs from MEXC at runtime

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,7 +15,7 @@ from scalp.notifier import notify, _format_text
 from scalp import __version__, RiskManager
 from scalp.telegram_bot import init_telegram_bot
 
-from scalp.bot_config import CONFIG
+from scalp.bot_config import CONFIG, load_zero_fee_pairs
 from scalp.strategy import ema, cross
 from scalp.trade_utils import (
     compute_position_size,
@@ -170,7 +170,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     interval = cfg["INTERVAL"]
     ema_fast_n = cfg["EMA_FAST"]
     ema_slow_n = cfg["EMA_SLOW"]
-    zero_fee_pairs = set(cfg.get("ZERO_FEE_PAIRS", []))
+    zero_fee_pairs = set(load_zero_fee_pairs())
     fee_rate = 0.0 if symbol in zero_fee_pairs else cfg.get("FEE_RATE", 0.0)
 
     contract_detail = client.get_contract_detail(symbol)

--- a/scalp/backtest/__init__.py
+++ b/scalp/backtest/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from scalp.bot_config import CONFIG
+from scalp.bot_config import CONFIG, load_zero_fee_pairs
 from scalp.metrics import calc_pnl_pct
 from .walkforward import walk_forward
 
@@ -23,7 +23,7 @@ def backtest_trades(
     trade will be recorded with the computed PnL.
     """
     fee_rate = fee_rate if fee_rate is not None else CONFIG.get("FEE_RATE", 0.0)
-    zero_fee = set(zero_fee_pairs or CONFIG.get("ZERO_FEE_PAIRS", []))
+    zero_fee = set(zero_fee_pairs or load_zero_fee_pairs())
 
     pnl = 0.0
     for tr in trades:

--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Callable
 
-from scalp.bot_config import CONFIG
+from scalp.bot_config import CONFIG, load_zero_fee_pairs
 from scalp.strategy import ema as default_ema, cross as default_cross
 from scalp.notifier import notify
 
@@ -27,7 +27,7 @@ def filter_trade_pairs(
 ) -> List[Dict[str, Any]]:
     """Filter pairs by volume, spread and zero fees."""
     pairs = get_trade_pairs(client)
-    zero_fee = set(zero_fee_pairs or CONFIG.get("ZERO_FEE_PAIRS", []))
+    zero_fee = set(zero_fee_pairs or load_zero_fee_pairs())
     eligible: List[Dict[str, Any]] = []
 
     for info in pairs:

--- a/tests/test_zero_fee_fetch.py
+++ b/tests/test_zero_fee_fetch.py
@@ -1,0 +1,28 @@
+import importlib
+from types import SimpleNamespace
+
+import requests
+
+
+def _fake_resp(data):
+    return SimpleNamespace(json=lambda: data)
+
+
+def test_fetch_zero_fee_pairs(monkeypatch):
+    def fake_get(url, timeout=5):
+        return _fake_resp(
+            {
+                "data": [
+                    {"symbol": "AAA_USDT", "takerFeeRate": 0, "makerFeeRate": 0},
+                    {"symbol": "BBB_USDT", "takerFeeRate": 0.001, "makerFeeRate": 0.001},
+                    {"symbol": "BTC_USDT", "takerFeeRate": 0, "makerFeeRate": 0},
+                ]
+            }
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
+    import scalp.bot_config as bc
+    importlib.reload(bc)
+    pairs = bc.fetch_zero_fee_pairs_from_mexc("http://example.com")
+    assert pairs == ["AAA_USDT"]
+


### PR DESCRIPTION
## Summary
- fetch zero-fee trading pairs directly from MEXC instead of relying on env var
- refresh zero-fee list when filtering pairs, backtesting or starting the bot
- add tests for dynamic zero-fee retrieval and default symbol selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe68139c8327b487b2cf2e3e0344