### PR TITLE
feat(bot): show menu after startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -266,6 +266,8 @@ def main(argv: Optional[List[str]] = None) -> None:
         send_selected_pairs(client, top_n=20, tg_bot=tg_bot)
     except Exception as exc:  # pragma: no cover - network
         logging.error("Erreur sélection paires: %s", exc)
+    if tg_bot:
+        tg_bot.send_main_menu(0.0)
     next_update = time.time() + 60
     while True:
         if tg_bot:


### PR DESCRIPTION
## Summary
- ensure Telegram choice buttons are shown immediately after startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4043a0ecc83279af82639c45caad6