### PR TITLE
Display selected cryptos when updating list

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -95,7 +95,8 @@ def find_trade_positions(
 
 def send_selected_pairs(
     client: Any, top_n: int = 20, tg_bot: Any | None = None
-) -> None:
+) -> Dict[str, str]:
+    """Send the selected trading pairs and return the payload."""
     payload = _pairs.send_selected_pairs(
         client,
         top_n=top_n,
@@ -104,11 +105,15 @@ def send_selected_pairs(
     )
     if tg_bot and payload:
         tg_bot.send(_format_text("pair_list", payload))
+    return payload
 
 
-def update(client: Any, top_n: int = 20, tg_bot: Any | None = None) -> None:
+def update(client: Any, top_n: int = 20, tg_bot: Any | None = None) -> Dict[str, str]:
     """Send a fresh list of pairs to reflect current market conditions."""
-    send_selected_pairs(client, top_n=top_n, tg_bot=tg_bot)
+    payload = send_selected_pairs(client, top_n=top_n, tg_bot=tg_bot)
+    text = _format_text("pair_list", payload)
+    logging.info(text)
+    return payload
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bot_update.py
+++ b/tests/test_bot_update.py
@@ -1,12 +1,14 @@
+import logging
 import bot
 
 
-def test_update_calls_send_selected_pairs(monkeypatch):
-    calls = []
-
+def test_update_displays_pairs(monkeypatch, caplog):
     def fake_send(client, top_n=20, tg_bot=None):
-        calls.append((client, top_n, tg_bot))
+        assert (client, top_n, tg_bot) == ("cli", 5, "tg")
+        return {"green": "BTC", "orange": "ETH", "red": "XRP"}
 
     monkeypatch.setattr(bot, "send_selected_pairs", fake_send)
-    bot.update("cli", top_n=5, tg_bot="tg")
-    assert calls == [("cli", 5, "tg")]
+    with caplog.at_level(logging.INFO):
+        payload = bot.update("cli", top_n=5, tg_bot="tg")
+    assert payload["green"] == "BTC"
+    assert "BTC" in caplog.text and "ETH" in caplog.text and "XRP" in caplog.text


### PR DESCRIPTION
## Summary
- return payload from `send_selected_pairs`
- log formatted pair list during `update`
- update test to assert logged output and payload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4046a55f0832781bc602daaa1d8fe