### PR TITLE
Print fee rates for MEXC pairs

### DIFF
--- a/tests/test_zero_fee_fetch.py
+++ b/tests/test_zero_fee_fetch.py
@@ -8,7 +8,7 @@ def _fake_resp(data):
     return SimpleNamespace(json=lambda: data)
 
 
-def test_fetch_zero_fee_pairs(monkeypatch):
+def test_fetch_zero_fee_pairs(monkeypatch, capsys):
     def fake_get(url, timeout=5):
         return _fake_resp(
             {
@@ -23,6 +23,34 @@ def test_fetch_zero_fee_pairs(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get, raising=False)
     import scalp.bot_config as bc
     importlib.reload(bc)
+    capsys.readouterr()
     pairs = bc.fetch_zero_fee_pairs_from_mexc("http://example.com")
     assert pairs == ["AAA_USDT"]
+    out, _ = capsys.readouterr()
+    assert "Zero-fee pairs: ['AAA_USDT']" in out
+
+
+def test_fetch_pairs_with_fees(monkeypatch, capsys):
+    def fake_get(url, timeout=5):
+        return _fake_resp(
+            {
+                "data": [
+                    {"symbol": "AAA_USDT", "takerFeeRate": 0, "makerFeeRate": 0},
+                    {"symbol": "BBB_USDT", "takerFeeRate": 0.001, "makerFeeRate": 0.001},
+                ]
+            }
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
+    import scalp.bot_config as bc
+    importlib.reload(bc)
+    capsys.readouterr()
+    items = bc.fetch_pairs_with_fees_from_mexc("http://example.com")
+    assert items == [
+        ("AAA_USDT", 0.0, 0.0),
+        ("BBB_USDT", 0.001, 0.001),
+    ]
+    out, _ = capsys.readouterr()
+    assert "AAA_USDT: maker=0.0, taker=0.0" in out
+    assert "BBB_USDT: maker=0.001, taker=0.001" in out
 


### PR DESCRIPTION
## Summary
- add helper to fetch and print MEXC fee rates for each trading pair
- reuse helper in zero-fee pair discovery
- test fee-rate retrieval and debug output
- print final zero-fee list for easier terminal inspection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40b213dd883278dedef73ea107321