### PR TITLE
Load env from notebook parent

### DIFF
--- a/scalp/__init__.py
+++ b/scalp/__init__.py
@@ -1,24 +1,33 @@
 """Utilities and helpers for Scalp bot.
 
-This module also looks for a ``.env`` file located one directory above the
-repository (e.g. ``Notebooks/.env`` when the project lives in
-``Notebooks/scalp``) and loads any variables found there.  This allows users to
-store private API keys outside of the git repository while still making them
-available to the bot at runtime.
+When the bot is executed from ``notebook/spot/mexc_bot.py`` it expects secret
+keys to live in ``notebook/.env``.  On import this module attempts to load the
+variables from that file so that API keys can remain outside of the repository
+yet still be available at runtime.
 """
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
+import sys
 
 
 def _load_parent_env() -> None:
-    """Load environment variables from ``../.env`` if present."""
+    """Load environment variables from ``../.env`` relative to the entry script.
 
-    env_file = Path(__file__).resolve().parents[2] / ".env"
+    The bot is typically launched from ``notebook/spot/mexc_bot.py`` and keys
+    are expected to be stored one directory above (``notebook/.env``).  If that
+    file is not found the function falls back to the historical behaviour of
+    checking ``../.env`` relative to the package itself.
+    """
+
+    script_path = Path(sys.argv[0]).resolve()
+    env_file = script_path.parent.parent / ".env"
     if not env_file.exists():
-        return
+        env_file = Path(__file__).resolve().parents[2] / ".env"
+        if not env_file.exists():
+            return
 
     try:
         from dotenv import load_dotenv

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,22 +1,26 @@
-"""Tests for loading environment variables from parent .env file."""
+"""Tests for loading environment variables from ``notebook/.env``."""
 
 from __future__ import annotations
 
 import importlib
 import os
+import sys
 from pathlib import Path
 
 
-def test_parent_env_loaded(tmp_path) -> None:
-    """Module should load variables from ``../.env`` if present."""
+def test_parent_env_loaded(tmp_path, monkeypatch) -> None:
+    """Module should load variables from ``notebook/.env`` if present."""
 
-    parent = Path(__file__).resolve().parents[2]
-    env_file = parent / ".env"
+    notebook = tmp_path / "notebook"
+    spot = notebook / "spot"
+    spot.mkdir(parents=True)
+    mexc_bot = spot / "mexc_bot.py"
+    mexc_bot.write_text("")
+    env_file = notebook / ".env"
     env_file.write_text("MEXC_ACCESS_KEY=from_env\n")
 
-    # Ensure any previous value is cleared then reload the package to trigger
-    # the loading logic.
     old = os.environ.pop("MEXC_ACCESS_KEY", None)
+    monkeypatch.setattr(sys, "argv", [str(mexc_bot)])
     import scalp
 
     importlib.reload(scalp)


### PR DESCRIPTION
## Summary
- load .env relative to entry script, allowing mexc_bot.py to use notebook/.env
- update env loading test to simulate notebook/spot scenario

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a42ce3b7c88327acd6c374e896e3f5