### PR TITLE
Add context manager support and refactors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,7 +15,7 @@ from scalp.notifier import notify, _format_text
 from scalp import __version__, RiskManager
 from scalp.telegram_bot import init_telegram_bot
 
-from scalp.bot_config import CONFIG, load_zero_fee_pairs
+from scalp.bot_config import CONFIG, get_zero_fee_pairs
 from scalp.strategy import ema, cross
 from scalp.trade_utils import (
     compute_position_size,
@@ -175,7 +175,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     interval = cfg["INTERVAL"]
     ema_fast_n = cfg["EMA_FAST"]
     ema_slow_n = cfg["EMA_SLOW"]
-    zero_fee_pairs = set(load_zero_fee_pairs())
+    zero_fee_pairs = set(get_zero_fee_pairs())
     fee_rate = 0.0 if symbol in zero_fee_pairs else cfg.get("FEE_RATE", 0.0)
 
     contract_detail = client.get_contract_detail(symbol)

--- a/scalp/backtest/__init__.py
+++ b/scalp/backtest/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from scalp.bot_config import CONFIG, load_zero_fee_pairs
+from scalp.bot_config import CONFIG, get_zero_fee_pairs
 from scalp.metrics import calc_pnl_pct
 from .walkforward import walk_forward
 
@@ -23,7 +23,7 @@ def backtest_trades(
     trade will be recorded with the computed PnL.
     """
     fee_rate = fee_rate if fee_rate is not None else CONFIG.get("FEE_RATE", 0.0)
-    zero_fee = set(zero_fee_pairs or load_zero_fee_pairs())
+    zero_fee = set(zero_fee_pairs or get_zero_fee_pairs())
 
     pnl = 0.0
     for tr in trades:

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -38,82 +38,91 @@ def _pair_name(symbol: str) -> str:
     return f"{base}/{quote}"
 
 
-def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:
-    """Return a human readable text describing the event payload."""
-    if event in {"position_opened", "position_closed"}:
-        action = "Ouvre" if event == "position_opened" else "Ferme"
-        side = payload.get("side") if payload else None
-        if side:
-            side = f"{side} {'📈' if side == 'long' else '📉'}"
-        symbol = payload.get("symbol") if payload else None
-        if symbol:
-            symbol = _pair_name(symbol)
-        pnl_pct = payload.get("pnl_pct") if payload else None
-        icons = ""
-        if event == "position_closed" and pnl_pct is not None:
-            icons = ("✅🎯" if pnl_pct > 0 else "❌🛑")
-        head = " ".join(p for p in [action, side, symbol, icons] if p)
+def _format_position_event(event: str, payload: Dict[str, Any]) -> str:
+    """Format a position open/close payload."""
+    action = "Ouvre" if event == "position_opened" else "Ferme"
+    side = payload.get("side")
+    if side:
+        side = f"{side} {'📈' if side == 'long' else '📉'}"
+    symbol = payload.get("symbol")
+    if symbol:
+        symbol = _pair_name(symbol)
+    pnl_pct = payload.get("pnl_pct")
+    icons = ""
+    if event == "position_closed" and pnl_pct is not None:
+        icons = "✅🎯" if pnl_pct > 0 else "❌🛑"
+    head = " ".join(p for p in [action, side, symbol, icons] if p)
 
-        lines = [head]
-        if payload:
-            vol = payload.get("vol")
-            if vol is not None:
-                lines.append(f"Position: {vol}")
-            lev = payload.get("leverage")
+    lines = [head]
+    vol = payload.get("vol")
+    if vol is not None:
+        lines.append(f"Position: {vol}")
+    lev = payload.get("leverage")
+    if lev is not None:
+        lines.append(f"Levier: x{lev}")
+    if event == "position_opened":
+        tp_usd = payload.get("tp_usd")
+        sl_usd = payload.get("sl_usd")
+        if tp_usd is not None and sl_usd is not None:
+            lines.append(f"TP: +{tp_usd} USDT")
+            lines.append(f"SL: -{sl_usd} USDT")
+        else:
+            tp = payload.get("tp_pct")
+            sl = payload.get("sl_pct")
+            if tp is not None and sl is not None:
+                lines.append(f"TP: +{tp:.2f}%")
+                lines.append(f"SL: -{sl:.2f}%")
+        hold = payload.get("hold") or payload.get("expected_duration")
+        if hold is not None:
+            lines.append(f"Durée prévue: {hold}")
+    else:  # position_closed
+        pnl_usd = payload.get("pnl_usd")
+        if pnl_usd is not None and pnl_pct is not None:
+            lines.append(f"PnL: {pnl_usd} USDT ({pnl_pct:.2f}%)")
+        elif pnl_pct is not None:
+            lines.append(f"PnL: {pnl_pct:.2f}%")
+        dur = payload.get("duration")
+        if dur is not None:
+            lines.append(f"Durée: {dur}")
+    return "\n".join(lines)
 
-            if lev is not None:
-                lines.append(f"Levier: x{lev}")
 
-            if event == "position_opened":
-                tp_usd = payload.get("tp_usd")
-                sl_usd = payload.get("sl_usd")
-                if tp_usd is not None and sl_usd is not None:
-                    lines.append(f"TP: +{tp_usd} USDT")
-                    lines.append(f"SL: -{sl_usd} USDT")
-                else:
-                    tp = payload.get("tp_pct")
-                    sl = payload.get("sl_pct")
-                    if tp is not None and sl is not None:
-                        lines.append(f"TP: +{tp:.2f}%")
-                        lines.append(f"SL: -{sl:.2f}%")
-                hold = payload.get("hold") or payload.get("expected_duration")
-                if hold is not None:
-                    lines.append(f"Durée prévue: {hold}")
-            else:  # position_closed
-                pnl_usd = payload.get("pnl_usd")
-                if pnl_usd is not None and pnl_pct is not None:
-                    lines.append(f"PnL: {pnl_usd} USDT ({pnl_pct:.2f}%)")
-                elif pnl_pct is not None:
-                    lines.append(f"PnL: {pnl_pct:.2f}%")
-                dur = payload.get("duration")
-                if dur is not None:
-                    lines.append(f"Durée: {dur}")
+def _format_pair_list(payload: Dict[str, Any]) -> str:
+    """Format the pair list payload."""
+    green = payload.get("green")
+    orange = payload.get("orange")
+    red = payload.get("red")
+    if green or orange or red:
+        lines = ["Listing :"]
+        if green:
+            lines.append(f"🟢 {green}")
+        if orange:
+            lines.append(f"🟠 {orange}")
+        if red:
+            lines.append(f"🔴 {red}")
         return "\n".join(lines)
+    pairs = payload.get("pairs", "")
+    return f"Listing : {pairs}"
 
-    if event == "bot_started":
-        return "🤖 Bot démarré"
-    if event == "pair_list":
-        if payload:
-            green = payload.get("green")
-            orange = payload.get("orange")
-            red = payload.get("red")
-            if green or orange or red:
-                lines = ["Listing :"]
-                if green:
-                    lines.append(f"🟢 {green}")
-                if orange:
-                    lines.append(f"🟠 {orange}")
-                if red:
-                    lines.append(f"🔴 {red}")
-                return "\n".join(lines)
-        pairs = payload.get("pairs") if payload else ""
-        return f"Listing : {pairs}"
 
+def _format_generic(event: str, payload: Dict[str, Any]) -> str:
     text = event
     if payload:
         items = "\n".join(f"{k}={v}" for k, v in payload.items())
         text = f"{text}\n{items}"
     return text
+
+
+def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:
+    """Return a human readable text describing the event payload."""
+    payload = payload or {}
+    if event in {"position_opened", "position_closed"}:
+        return _format_position_event(event, payload)
+    if event == "pair_list":
+        return _format_pair_list(payload)
+    if event == "bot_started":
+        return "🤖 Bot démarré"
+    return _format_generic(event, payload)
 
 
 def notify(event: str, payload: Dict[str, Any] | None = None) -> None:

--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -107,10 +107,12 @@ def send_selected_pairs(
     *,
     select_fn: Callable[[Any, int], List[Dict[str, Any]]] = select_top_pairs,
     notify_fn: Callable[[str, Optional[Dict[str, Any]]], None] = notify,
-) -> None:
+) -> Dict[str, str]:
     """Fetch top pairs, drop USD/USDT/USDC duplicates and notify their list.
 
-    Returns the payload sent to ``notify_fn`` for convenience.
+    Returns the payload sent to ``notify_fn``. The mapping contains the
+    comma-separated symbols for each color group (``green``, ``orange`` and
+    ``red``) or an empty dictionary when no pairs are available.
     """
 
     def split_symbol(sym: str) -> tuple[str, str]:

--- a/scalp/ws.py
+++ b/scalp/ws.py
@@ -57,3 +57,14 @@ class WebsocketManager:
                 logging.warning("websocket heartbeat failed: %s", exc)
                 await self.run()
                 break
+
+    async def stop(self) -> None:
+        """Cancel the heartbeat task if it is running."""
+        task = self._heartbeat_task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except BaseException:  # pragma: no cover - cancellation
+                pass
+        self._heartbeat_task = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,13 @@ import hashlib
 import pytest
 import bot
 from bot import MexcFuturesClient
+import sys
+import importlib
+
+sys.modules.pop("requests", None)
+real_requests = importlib.import_module("requests")
+sys.modules["requests"] = real_requests
+import scalp.client as http_client
 
 
 @pytest.fixture(autouse=True)
@@ -101,3 +108,37 @@ def test_get_assets_paper_trade():
     assert assets["success"] is True
     usdt = next((row for row in assets.get("data", []) if row.get("currency") == "USDT"), None)
     assert usdt and usdt["equity"] == 100.0
+
+
+def test_http_client_context_manager(monkeypatch):
+    closed = {"count": 0}
+
+    class DummySession:
+        def mount(self, *a, **k):
+            pass
+
+        def request(self, *a, **k):
+            class Resp:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {}
+
+                text = "{}"
+
+            return Resp()
+
+        def close(self):
+            closed["count"] += 1
+
+    monkeypatch.setattr(http_client.requests, "Session", lambda: DummySession())
+
+    http = http_client.HttpClient("http://example.com")
+    http.close()
+    assert closed["count"] == 1
+
+    closed["count"] = 0
+    with http_client.HttpClient("http://example.com") as hc:
+        hc.request("GET", "/")
+    assert closed["count"] == 1

--- a/tests/test_config_symbol.py
+++ b/tests/test_config_symbol.py
@@ -8,24 +8,22 @@ def _fake_resp(data):
     return SimpleNamespace(json=lambda: data)
 
 
-def test_symbol_defaults_to_zero_fee_pair(monkeypatch):
+def test_symbol_defaults_without_network(monkeypatch):
     monkeypatch.delenv("SYMBOL", raising=False)
     monkeypatch.delenv("ZERO_FEE_PAIRS", raising=False)
 
+    called = False
+
     def fake_get(url, timeout=5):
-        return _fake_resp(
-            {
-                "data": [
-                    {"symbol": "WIF_USDT", "takerFeeRate": 0, "makerFeeRate": 0},
-                    {"symbol": "DOGE_USDT", "takerFeeRate": 0, "makerFeeRate": 0},
-                ]
-            }
-        )
+        nonlocal called
+        called = True
+        return _fake_resp({"data": []})
 
     monkeypatch.setattr(requests, "get", fake_get, raising=False)
     import scalp.bot_config as bc
     importlib.reload(bc)
-    assert bc.CONFIG["SYMBOL"] == "WIF_USDT"
+    assert bc.CONFIG["SYMBOL"] == "BTC_USDT"
+    assert called is False
 
 
 def test_zero_fee_pairs_excludes_btc_eth(monkeypatch):
@@ -45,4 +43,4 @@ def test_zero_fee_pairs_excludes_btc_eth(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get, raising=False)
     import scalp.bot_config as bc
     importlib.reload(bc)
-    assert bc.CONFIG["ZERO_FEE_PAIRS"] == ["DOGE_USDT"]
+    assert bc.get_zero_fee_pairs() == ["DOGE_USDT"]

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -122,3 +122,22 @@ def test_format_text_pair_list_and_start():
     assert text == "Listing :\n🟢 AAA\n🟠 BBB\n🔴 CCC"
 
 
+def test_format_pair_list_helper():
+    payload = {"green": "AAA", "orange": "BBB", "red": "CCC"}
+    text = notifier._format_pair_list(payload)
+    assert text == "Listing :\n🟢 AAA\n🟠 BBB\n🔴 CCC"
+
+
+def test_format_position_event_helper():
+    payload = {
+        "side": "long",
+        "symbol": "BTCUSDT",
+        "vol": 1,
+        "leverage": 10,
+        "tp_pct": 5,
+        "sl_pct": 2,
+    }
+    text = notifier._format_position_event("position_opened", payload)
+    assert text.splitlines()[0] == "Ouvre long 📈 BTC"
+
+

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -23,12 +23,13 @@ def test_send_selected_pairs(monkeypatch):
         ],
     )
 
-    bot.send_selected_pairs(object(), top_n=4)
+    payload = bot.send_selected_pairs(object(), top_n=4)
 
     assert sent["event"] == "pair_list"
     assert sent["payload"]["green"] == "WIF"
     assert sent["payload"]["orange"] == "BTC"
     assert sent["payload"]["red"] == "DOGE, ETH"
+    assert payload == sent["payload"]
 
 
 def test_filter_trade_pairs_all_pairs(monkeypatch):

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from scalp.ws import WebsocketManager
+
+
+def test_websocket_manager_stop():
+    async def connect():
+        return None
+
+    async def subscribe():
+        return None
+
+    ws = WebsocketManager(connect, subscribe, heartbeat_interval=0.01)
+
+    async def run_and_stop():
+        await ws.run()
+        assert ws._heartbeat_task is not None
+        await ws.stop()
+        assert ws._heartbeat_task is None
+
+    asyncio.run(run_and_stop())

--- a/tests/test_zero_fee_fetch.py
+++ b/tests/test_zero_fee_fetch.py
@@ -1,5 +1,7 @@
 import importlib
 from types import SimpleNamespace
+from types import SimpleNamespace
+import importlib
 
 import requests
 
@@ -8,7 +10,7 @@ def _fake_resp(data):
     return SimpleNamespace(json=lambda: data)
 
 
-def test_fetch_zero_fee_pairs(monkeypatch, capsys):
+def test_fetch_zero_fee_pairs(monkeypatch):
     def fake_get(url, timeout=5):
         return _fake_resp(
             {
@@ -23,39 +25,11 @@ def test_fetch_zero_fee_pairs(monkeypatch, capsys):
     monkeypatch.setattr(requests, "get", fake_get, raising=False)
     import scalp.bot_config as bc
     importlib.reload(bc)
-    capsys.readouterr()
     pairs = bc.fetch_zero_fee_pairs_from_mexc("http://example.com")
     assert pairs == ["AAA_USDT"]
-    out, _ = capsys.readouterr()
-    assert "Zero-fee pairs: ['AAA_USDT']" in out
 
 
-def test_fetch_pairs_with_fees(monkeypatch, capsys):
-    def fake_get(url, timeout=5):
-        return _fake_resp(
-            {
-                "data": [
-                    {"symbol": "AAA_USDT", "takerFeeRate": 0, "makerFeeRate": 0},
-                    {"symbol": "BBB_USDT", "takerFeeRate": 0.001, "makerFeeRate": 0.001},
-                ]
-            }
-        )
-
-    monkeypatch.setattr(requests, "get", fake_get, raising=False)
-    import scalp.bot_config as bc
-    importlib.reload(bc)
-    capsys.readouterr()
-    items = bc.fetch_pairs_with_fees_from_mexc("http://example.com")
-    assert items == [
-        ("AAA_USDT", 0.0, 0.0),
-        ("BBB_USDT", 0.001, 0.001),
-    ]
-    out, _ = capsys.readouterr()
-    assert "AAA_USDT: maker=0.0, taker=0.0" in out
-    assert "BBB_USDT: maker=0.001, taker=0.001" in out
-
-
-def test_fetch_pairs_with_fees(monkeypatch, capsys):
+def test_fetch_pairs_with_fees(monkeypatch):
     def fake_get(url, timeout=5):
         return _fake_resp(
             {
@@ -74,7 +48,4 @@ def test_fetch_pairs_with_fees(monkeypatch, capsys):
         ("AAA_USDT", 0.0, 0.0),
         ("BBB_USDT", 0.001, 0.001),
     ]
-    out, _ = capsys.readouterr()
-    assert "AAA_USDT: maker=0.0, taker=0.0" in out
-    assert "BBB_USDT: maker=0.001, taker=0.001" in out
 


### PR DESCRIPTION
## Summary
- add `HttpClient.close()` and context-manager protocol
- fix `send_selected_pairs` return type
- lazily load zero-fee pairs and remove prints
- split notifier formatting into helpers
- provide stoppable websocket manager

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a479af83bc832796540cd98706b1f6