### PR TITLE
Fix Bitget API signature encoding

### DIFF
--- a/notebooks/spot/bitget_bot.py
+++ b/notebooks/spot/bitget_bot.py
@@ -2,6 +2,7 @@ import os
 import time
 import hmac
 import hashlib
+import base64
 import logging
 from argparse import ArgumentParser
 from pathlib import Path
@@ -49,7 +50,9 @@ class BitgetClient:
             params["timestamp"] = self._timestamp()
             params["recvWindow"] = RECV_WINDOW
             query = urlencode(params)
-            signature = hmac.new(self.api_secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+            signature = base64.b64encode(
+                hmac.new(self.api_secret.encode(), query.encode(), hashlib.sha256).digest()
+            ).decode()
             query += f"&signature={signature}"
             headers = {"X-BITGET-APIKEY": self.api_key}
             if method.upper() == "GET":

--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -55,7 +55,9 @@ class BitgetFuturesClient:
         return "&".join(items)
 
     def _sign(self, prehash: str) -> str:
-        return hmac.new(self.sk.encode(), prehash.encode(), hashlib.sha256).hexdigest()
+        """Return a base64-encoded HMAC SHA256 signature."""
+        digest = hmac.new(self.sk.encode(), prehash.encode(), hashlib.sha256).digest()
+        return base64.b64encode(digest).decode()
 
     def _headers(self, signature: str, timestamp: int) -> Dict[str, str]:
         headers = {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,7 +39,9 @@ def test_private_request_get_signature(monkeypatch):
     assert resp["success"] is True
     qs = "a=1&b=2"
     prehash = f"1000GET/api/test?{qs}"
-    expected = hmac.new(b"secret", prehash.encode(), hashlib.sha256).hexdigest()
+    expected = base64.b64encode(
+        hmac.new(b"secret", prehash.encode(), hashlib.sha256).digest()
+    ).decode()
     assert called["headers"]["ACCESS-SIGN"] == expected
     assert called["headers"]["ACCESS-KEY"] == "key"
     assert called["headers"]["ACCESS-TIMESTAMP"] == "1000"
@@ -73,7 +75,9 @@ def test_private_request_post_signature(monkeypatch):
     assert resp["success"] is True
     body = json.dumps({"a": 1, "b": 2}, separators=(",", ":"), ensure_ascii=False)
     prehash = f"1000POST/api/test{body}"
-    expected = hmac.new(b"secret", prehash.encode(), hashlib.sha256).hexdigest()
+    expected = base64.b64encode(
+        hmac.new(b"secret", prehash.encode(), hashlib.sha256).digest()
+    ).decode()
     assert called["headers"]["ACCESS-SIGN"] == expected
     assert called["headers"]["ACCESS-KEY"] == "key"
     assert called["headers"]["ACCESS-TIMESTAMP"] == "1000"


### PR DESCRIPTION
## Summary
- Use base64-encoded HMAC SHA256 signatures for Bitget client and spot bot
- Update client tests to verify base64 signatures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4901080588327a9ac795e93e51a5e