### PR TITLE
feat: add quick bitget order helpers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -140,6 +140,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         base_url=cfg["BASE_URL"],
         recv_window=cfg["RECV_WINDOW"],
         paper_trade=cfg["PAPER_TRADE"],
+        passphrase=cfg.get("BITGET_PASSPHRASE"),
     )
     risk_mgr = RiskManager(
         max_daily_loss_pct=cfg["MAX_DAILY_LOSS_PCT"],
@@ -157,10 +158,10 @@ def main(argv: Optional[List[str]] = None) -> None:
     except Exception as exc:  # pragma: no cover - best effort
         logging.error("Erreur annulation ordres ouverts: %s", exc)
     try:
-        positions = client.get_positions()
+        positions = client.get_positions(product_type=cfg["PRODUCT_TYPE"])
         if positions.get("data"):
             logging.info("Fermeture des positions ouvertes au démarrage")
-            client.close_all_positions()
+            client.close_all_positions(product_type=cfg["PRODUCT_TYPE"])
     except Exception as exc:  # pragma: no cover - best effort
         logging.error("Erreur fermeture positions existantes: %s", exc)
 
@@ -410,7 +411,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     distance_mult=cfg["SCALE_IN_ATR_MULT"],
                 )
             ):
-                positions = client.get_positions().get("data", [])
+                positions = client.get_positions(product_type=cfg["PRODUCT_TYPE"]).get("data", [])
                 if risk_mgr.can_open(len(positions)):
                     vol_add = compute_position_size(
                         contract_detail,
@@ -445,7 +446,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     distance_mult=cfg["SCALE_IN_ATR_MULT"],
                 )
             ):
-                positions = client.get_positions().get("data", [])
+                positions = client.get_positions(product_type=cfg["PRODUCT_TYPE"]).get("data", [])
                 if risk_mgr.can_open(len(positions)):
                     vol_add = compute_position_size(
                         contract_detail,
@@ -485,7 +486,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     if close_position(-1, price, vol_close):
                         break
 
-                positions = client.get_positions().get("data", [])
+                positions = client.get_positions(product_type=cfg["PRODUCT_TYPE"]).get("data", [])
                 if not risk_mgr.can_open(len(positions)):
                     logging.info("RiskManager: limites atteintes, on attend.")
                     time.sleep(cfg["LOOP_SLEEP_SECS"])
@@ -551,7 +552,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                     if close_position(1, price, vol_close):
                         break
 
-                positions = client.get_positions().get("data", [])
+                positions = client.get_positions(product_type=cfg["PRODUCT_TYPE"]).get("data", [])
                 if not risk_mgr.can_open(len(positions)):
                     logging.info("RiskManager: limites atteintes, on attend.")
                     time.sleep(cfg["LOOP_SLEEP_SECS"])

--- a/quick_order.py
+++ b/quick_order.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Submit a simple market order on Bitget futures.
+
+This helper reads API credentials and trade parameters from environment
+variables (optionally loaded from a `.env` file) and places a one-way
+market order.  Only the essential steps from the user's reference script
+are kept to minimise latency and redundant code.
+
+Environment variables:
+    BITGET_API_KEY / BITGET_ACCESS_KEY
+    BITGET_API_SECRET / BITGET_SECRET_KEY
+    BITGET_API_PASSPHRASE
+    BITGET_BASE_URL (default https://api.bitget.com)
+    BITGET_PRODUCT_TYPE (default ``umcbl``)
+    BITGET_MARGIN_COIN (default ``USDT``)
+    BITGET_SYMBOL (e.g. ``BTCUSDT``)
+    BITGET_TEST_NOTIONAL_USDT (default ``5``)
+
+Usage:
+    python quick_order.py buy
+    python quick_order.py sell
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from scalp.bitget_client import BitgetFuturesClient
+
+# Load variables from `.env` if present
+load_dotenv(Path(__file__).resolve().parent / ".env")
+
+side = sys.argv[1].lower() if len(sys.argv) > 1 else "buy"
+if side not in {"buy", "sell"}:
+    raise SystemExit("Usage: quick_order.py [buy|sell]")
+
+base = os.getenv("BITGET_BASE_URL", "https://api.bitget.com")
+ak = os.getenv("BITGET_API_KEY") or os.getenv("BITGET_ACCESS_KEY")
+sk = os.getenv("BITGET_API_SECRET") or os.getenv("BITGET_SECRET_KEY")
+ph = os.getenv("BITGET_API_PASSPHRASE") or os.getenv("BITGET_PASSPHRASE")
+product_type = os.getenv("BITGET_PRODUCT_TYPE", "umcbl")
+margin_coin = os.getenv("BITGET_MARGIN_COIN", "USDT")
+symbol = (os.getenv("BITGET_SYMBOL", "BTCUSDT") or "BTCUSDT").replace("_", "").upper()
+notional = float(os.getenv("BITGET_TEST_NOTIONAL_USDT", "5"))
+
+if not (ak and sk and ph):
+    raise SystemExit("❌ BITGET_API_KEY/SECRET/PASSPHRASE manquants")
+
+client = BitgetFuturesClient(
+    access_key=ak,
+    secret_key=sk,
+    base_url=base,
+    passphrase=ph,
+    paper_trade=False,
+)
+
+tick = client.get_ticker(symbol)
+price = None
+try:
+    data = tick.get("data")
+    if isinstance(data, list) and data:
+        price = float(data[0].get("lastPrice"))
+    elif isinstance(data, dict):
+        price = float(data.get("lastPrice"))
+except Exception:
+    pass
+if price is None or price <= 0:
+    raise SystemExit("Prix introuvable pour le ticker")
+
+size = round(notional / price, 6)
+client.set_position_mode_one_way(symbol, product_type)
+client.set_leverage(symbol, product_type, margin_coin, leverage=2)
+resp = client.place_market_order_one_way(
+    symbol, side, size, product_type, margin_coin
+)
+print(resp)

--- a/scalp/bot_config.py
+++ b/scalp/bot_config.py
@@ -4,10 +4,15 @@ import os
 DEFAULT_SYMBOL = os.getenv("SYMBOL") or "BTC_USDT"
 
 CONFIG = {
-    "BITGET_ACCESS_KEY": os.getenv("BITGET_ACCESS_KEY", "A_METTRE"),
-    "BITGET_SECRET_KEY": os.getenv("BITGET_SECRET_KEY", "B_METTRE"),
+    "BITGET_ACCESS_KEY": os.getenv("BITGET_API_KEY")
+    or os.getenv("BITGET_ACCESS_KEY", "A_METTRE"),
+    "BITGET_SECRET_KEY": os.getenv("BITGET_API_SECRET")
+    or os.getenv("BITGET_SECRET_KEY", "B_METTRE"),
+    "BITGET_PASSPHRASE": os.getenv("BITGET_API_PASSPHRASE", ""),
     "PAPER_TRADE": os.getenv("PAPER_TRADE", "true").lower() in ("1", "true", "yes", "y"),
     "SYMBOL": DEFAULT_SYMBOL,
+    "PRODUCT_TYPE": os.getenv("BITGET_PRODUCT_TYPE", "umcbl"),
+    "MARGIN_COIN": os.getenv("BITGET_MARGIN_COIN", "USDT"),
     "INTERVAL": os.getenv("INTERVAL", "Min1"),
     "EMA_FAST": int(os.getenv("EMA_FAST", "9")),
     "EMA_SLOW": int(os.getenv("EMA_SLOW", "21")),


### PR DESCRIPTION
## Summary
- extend config with passphrase, product type and margin coin
- support one-way market orders in Bitget client
- add quick_order utility script for testing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6d86d96e48327bb850a9cc2d10f6c