### PR TITLE
Handle 404 errors for contract details

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -178,7 +178,11 @@ def main(argv: Optional[List[str]] = None) -> None:
     ema_slow_n = cfg["EMA_SLOW"]
     fee_rate = cfg.get("FEE_RATE", 0.0)
 
-    contract_detail = client.get_contract_detail(symbol)
+    try:
+        contract_detail = client.get_contract_detail(symbol)
+    except requests.HTTPError as exc:  # pragma: no cover - network issues
+        logging.error("Erreur r\u00e9cup\u00e9ration contract detail: %s", exc)
+        contract_detail = {"success": False, "code": 404}
     log_event("contract_detail", contract_detail)
 
     assets = client.get_assets()
@@ -625,4 +629,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual run
-    main()
+    try:
+        main()
+    except requests.HTTPError as exc:  # pragma: no cover - network issues
+        logging.error("Erreur HTTP principale: %s", exc)

--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -81,6 +81,9 @@ class BitgetFuturesClient:
         if symbol:
             params["symbol"] = symbol
         r = self.requests.get(url, params=params, timeout=15)
+        if r.status_code == 404:  # pragma: no cover - depends on network
+            logging.error("Contract detail introuvable pour %s", symbol)
+            return {"success": False, "code": 404, "data": None}
         r.raise_for_status()
         return r.json()
 


### PR DESCRIPTION
## Summary
- handle contract detail HTTP errors without crashing
- catch contract detail failures in bot main and final invocation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6dc484438832788fa29a4d93c50e8