### PR TITLE
fix: update Bitget v2 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Le bot lit sa configuration via des variables d'environnement :
 
 - `BITGET_ACCESS_KEY`, `BITGET_SECRET_KEY` : clés API Bitget (laisser les valeurs par défaut pour rester en mode papier).
 - `PAPER_TRADE` (`true`/`false`) : par défaut `true`, n'envoie aucun ordre réel.
-- `SYMBOL` : symbole du contrat futures (par défaut, `BTCUSDT_UMCBL`).
+- `SYMBOL` : symbole du contrat futures (par défaut, `BTCUSDT`).
 - `INTERVAL` : intervalle des chandeliers, ex. `Min1`, `Min5`.
 - `EMA_FAST`, `EMA_SLOW` : périodes des EMA utilisées par la stratégie.
 - `MACD_FAST`, `MACD_SLOW`, `MACD_SIGNAL` : paramètres du filtre de tendance MACD.

--- a/scalp/bot_config.py
+++ b/scalp/bot_config.py
@@ -1,7 +1,7 @@
 import os
 
 
-DEFAULT_SYMBOL = os.getenv("SYMBOL") or "BTCUSDT_UMCBL"
+DEFAULT_SYMBOL = os.getenv("SYMBOL") or "BTCUSDT"
 
 CONFIG = {
     "BITGET_ACCESS_KEY": os.getenv("BITGET_API_KEY")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -186,4 +186,8 @@ def test_get_kline_query_params(monkeypatch):
     client.get_kline("BTC_USDT", interval="Min1")
 
     assert called["url"].endswith("/api/v2/mix/market/candles")
-    assert called["params"] == {"symbol": "BTCUSDT_UMCBL", "granularity": "Min1"}
+    assert called["params"] == {
+        "symbol": "BTCUSDT",
+        "productType": "UMCBL",
+        "granularity": "Min1",
+    }


### PR DESCRIPTION
## Summary
- normalize symbols to remove product type suffix
- send `productType` parameter for public and private endpoints
- set default symbol to `BTCUSDT`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6e7ec4d748327a2e92a0b24ee81c5