### PR TITLE
feat: update bitget v2 endpoints and intervals

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -8,7 +8,7 @@ Ce fichier résume les modules et fonctions essentiels afin de recréer le bot d
 - `_noop_event(*args, **kwargs)` : fonction vide pour le logging d'événements.
 - `check_config()` : vérifie la présence des clés API Bitget et journalise un avertissement si elles manquent.
 - `BitgetSpotClient` : sous-classe du client spot Bitget qui injecte `requests` et la fonction `log_event`.
-- `find_trade_positions(client, pairs, interval="Min1", ema_fast_n=None, ema_slow_n=None)` : applique la stratégie EMA sur une liste de paires et renvoie les signaux.
+- `find_trade_positions(client, pairs, interval="1m", ema_fast_n=None, ema_slow_n=None)` : applique la stratégie EMA sur une liste de paires et renvoie les signaux.
 - `send_selected_pairs(client, top_n=20, tg_bot=None)` : sélectionne et notifie les paires les plus actives.
 - `update(client, top_n=20, tg_bot=None)` : rafraîchit la liste des paires et renvoie la charge utile envoyée.
 - `main(argv=None)` : initialise la configuration, le client, le `RiskManager`, le bot Telegram et exécute la boucle de trading.
@@ -74,7 +74,7 @@ Ce fichier résume les modules et fonctions essentiels afin de recréer le bot d
 
 ### bitget_client.py
 - `BitgetSpotClient(access_key, secret_key, base_url, recv_window=30, paper_trade=True, requests_module=requests, log_event=None)` : client REST léger pour le marché spot.
-  - `get_symbol_info(symbol=None)`, `get_kline(symbol, interval="Min1", start=None, end=None)`, `get_ticker(symbol=None)`.
+  - `get_symbol_info(symbol=None)`, `get_kline(symbol, interval="1m", start=None, end=None)`, `get_ticker(symbol=None)`.
   - `_private_request(method, path, params=None, body=None)` : signe et exécute les requêtes privées.
   - `get_account()`, `get_open_orders(symbol=None)`.
   - `place_order(symbol, side, quantity, order_type, price=None, reduce_only=False, stop_loss=None, take_profit=None)`.
@@ -84,7 +84,7 @@ Ce fichier résume les modules et fonctions essentiels afin de recréer le bot d
 - `get_trade_pairs(client)` : récupère toutes les paires via `get_ticker`.
 - `filter_trade_pairs(client, volume_min=5_000_000, max_spread_bps=5, top_n=20)` : filtre par volume/spread.
 - `select_top_pairs(client, top_n=10, key="volume")` : trie par volume ou autre clé.
-- `find_trade_positions(client, pairs, interval="Min1", ema_fast_n=None, ema_slow_n=None, ema_func=ema, cross_func=cross)` : signaux EMA croisement.
+- `find_trade_positions(client, pairs, interval="1m", ema_fast_n=None, ema_slow_n=None, ema_func=ema, cross_func=cross)` : signaux EMA croisement.
 - `send_selected_pairs(client, top_n=20, select_fn=select_top_pairs, notify_fn=notify)` : déduplique USD/USDT/USDC et notifie la liste.
 - `heat_score(volatility, volume, news=False)` : score combinant volatilite et volume.
 - `select_top_heat_pairs(pairs, top_n=3)` : sélection des paires les plus "chaudes".

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Le bot lit sa configuration via des variables d'environnement :
 - `BITGET_ACCESS_KEY`, `BITGET_SECRET_KEY` : clés API Bitget (laisser les valeurs par défaut pour rester en mode papier).
 - `PAPER_TRADE` (`true`/`false`) : par défaut `true`, n'envoie aucun ordre réel.
 - `SYMBOL` : symbole du contrat futures (par défaut, `BTCUSDT`).
-- `INTERVAL` : intervalle des chandeliers, ex. `Min1`, `Min5`.
+- `INTERVAL` : intervalle des chandeliers, ex. `1m`, `5m`.
 - `EMA_FAST`, `EMA_SLOW` : périodes des EMA utilisées par la stratégie.
 - `MACD_FAST`, `MACD_SLOW`, `MACD_SIGNAL` : paramètres du filtre de tendance MACD.
 - `EMA_TREND_PERIOD` : période de l'EMA longue utilisée comme filtre de tendance général.

--- a/bot.py
+++ b/bot.py
@@ -78,7 +78,7 @@ def find_trade_positions(
     client: Any,
     pairs: List[Dict[str, Any]],
     *,
-    interval: str = "Min1",
+    interval: str = "1m",
     ema_fast_n: Optional[int] = None,
     ema_slow_n: Optional[int] = None,
 ) -> List[Dict[str, Any]]:

--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -17,6 +17,20 @@ _PRODUCT_TYPE_ALIASES = {
     "CMCBL": "COIN-FUTURES",
 }
 
+# Granularity aliases from v1 to v2 nomenclature
+_GRANULARITY_ALIASES = {
+    "MIN1": "1m",
+    "MIN3": "3m",
+    "MIN5": "5m",
+    "MIN15": "15m",
+    "MIN30": "30m",
+    "HOUR1": "1H",
+    "HOUR4": "4H",
+    "HOUR12": "12H",
+    "DAY1": "1D",
+    "WEEK1": "1W",
+}
+
 
 class BitgetFuturesClient:
     """Lightweight REST client for Bitget LAPI v2 futures endpoints."""
@@ -129,7 +143,7 @@ class BitgetFuturesClient:
     def get_kline(
         self,
         symbol: str,
-        interval: str = "Min1",
+        interval: str = "1m",
         start: Optional[int] = None,
         end: Optional[int] = None,
     ) -> Dict[str, Any]:
@@ -137,10 +151,11 @@ class BitgetFuturesClient:
         # encoded in the path. Using ``/candles/{symbol}`` results in a 404
         # response from Bitget. See: https://api.bitget.com/api/v2/mix/market/candles
         url = f"{self.base}/api/v2/mix/market/candles"
+        interval_norm = _GRANULARITY_ALIASES.get(interval.replace("_", "").upper(), interval)
         params: Dict[str, Any] = {
             "symbol": self._format_symbol(symbol),
             "productType": self.product_type,
-            "granularity": interval,
+            "granularity": interval_norm,
         }
         if start is not None:
             params["startTime"] = int(start)
@@ -249,7 +264,7 @@ class BitgetFuturesClient:
         params: Dict[str, Any] = {"productType": self.product_type}
         if symbol:
             params["symbol"] = self._format_symbol(symbol)
-        return self._private_request("GET", "/api/v2/mix/order/current", params=params)
+        return self._private_request("GET", "/api/v2/mix/order/orders-pending", params=params)
 
     # Account configuration -------------------------------------------------
     def set_position_mode_one_way(self, symbol: str, product_type: Optional[str] = None) -> Dict[str, Any]:

--- a/scalp/bot_config.py
+++ b/scalp/bot_config.py
@@ -13,7 +13,7 @@ CONFIG = {
     "SYMBOL": DEFAULT_SYMBOL,
     "PRODUCT_TYPE": os.getenv("BITGET_PRODUCT_TYPE", "USDT-FUTURES"),
     "MARGIN_COIN": os.getenv("BITGET_MARGIN_COIN", "USDT"),
-    "INTERVAL": os.getenv("INTERVAL", "Min1"),
+    "INTERVAL": os.getenv("INTERVAL", "1m"),
     "EMA_FAST": int(os.getenv("EMA_FAST", "9")),
     "EMA_SLOW": int(os.getenv("EMA_SLOW", "21")),
     "MACD_FAST": int(os.getenv("MACD_FAST", "12")),

--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -72,7 +72,7 @@ def find_trade_positions(
     client: Any,
     pairs: List[Dict[str, Any]],
     *,
-    interval: str = "Min1",
+    interval: str = "1m",
     ema_fast_n: Optional[int] = None,
     ema_slow_n: Optional[int] = None,
     ema_func=default_ema,

--- a/short_one_way.py
+++ b/short_one_way.py
@@ -156,13 +156,13 @@ def get_price():
     except Exception as e:
         print("⚠️ tickers err:", e)
 
-    # 3) candles Min1 (close)
+    # 3) candles 1m (close)
     try:
         # ``symbol`` must be provided as a query parameter; placing it in the
         # path triggers a 404 response from Bitget.
         r = requests.get(
             f"{BASE}/api/v2/mix/market/candles",
-            params={"symbol": SYMB, "granularity": "Min1"},
+            params={"symbol": SYMB, "granularity": "1m"},
             timeout=10,
         )
         r.raise_for_status()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,7 +189,29 @@ def test_get_kline_query_params(monkeypatch):
     assert called["params"] == {
         "symbol": "BTCUSDT",
         "productType": "USDT-FUTURES",
-        "granularity": "Min1",
+        "granularity": "1m",
+    }
+
+
+def test_get_open_orders_endpoint(monkeypatch):
+    client = BitgetFuturesClient("key", "secret", "https://test")
+
+    called = {}
+
+    def fake_private(self, method, path, params=None, body=None):
+        called["method"] = method
+        called["path"] = path
+        called["params"] = params
+        return {"success": True}
+
+    monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
+
+    client.get_open_orders("BTCUSDT_UMCBL")
+
+    assert called["path"] == "/api/v2/mix/order/orders-pending"
+    assert called["params"] == {
+        "productType": "USDT-FUTURES",
+        "symbol": "BTCUSDT",
     }
 
 

--- a/tests/test_pair_selection.py
+++ b/tests/test_pair_selection.py
@@ -81,7 +81,7 @@ def test_find_trade_positions(monkeypatch):
                 "BBB": {"data": {"close": [3, 2, 1]}},
             }
 
-        def get_kline(self, symbol, interval="Min1"):
+        def get_kline(self, symbol, interval="1m"):
             return self.data[symbol]
 
     pairs = [


### PR DESCRIPTION
## Summary
- normalize candle intervals to Bitget v2 strings like `1m`
- switch open orders call to `/orders-pending` and handle v1 product type aliases
- document new interval naming and test the v2 endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6ec37b5208327b53898eaa9a559af