### PR TITLE
Handle Bitget v2 kline success code

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -298,7 +298,11 @@ def main(argv: Optional[List[str]] = None) -> None:
 
         try:
             k = client.get_kline(symbol, interval=interval)
-            if not (k and k.get("success") and "data" in k and "close" in k["data"]):
+            ok = False
+            if k:
+                code = k.get("code")
+                ok = (k.get("success") is True) or (isinstance(code, str) and code == "00000")
+            if not (ok and "data" in k and "close" in k["data"]):
                 logging.warning("Réponse klines inattendue: %s", k)
                 time.sleep(cfg["LOOP_SLEEP_SECS"])
                 continue


### PR DESCRIPTION
## Summary
- recognise Bitget v2 kline responses using `code` field, preventing spurious warnings in the trading loop

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f0a5f7a4832784f6e31e375d9fd5