### PR TITLE
Handle Bitget v2 ticker fields and cancel-all parameters

### DIFF
--- a/quick_order.py
+++ b/quick_order.py
@@ -63,9 +63,13 @@ price = None
 try:
     data = tick.get("data")
     if isinstance(data, list) and data:
-        price = float(data[0].get("lastPrice"))
+        price_str = data[0].get("lastPr") or data[0].get("lastPrice")
+        if price_str is not None:
+            price = float(price_str)
     elif isinstance(data, dict):
-        price = float(data.get("lastPrice"))
+        price_str = data.get("lastPr") or data.get("lastPrice")
+        if price_str is not None:
+            price = float(price_str)
 except Exception:
     pass
 if price is None or price <= 0:

--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -424,11 +424,19 @@ class BitgetFuturesClient:
             "POST", "/api/v2/mix/order/cancel-order", body={"orderIds": order_ids}
         )
 
-    def cancel_all(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+    def cancel_all(
+        self,
+        symbol: Optional[str] = None,
+        margin_coin: Optional[str] = None,
+    ) -> Dict[str, Any]:
         body = {"productType": self.product_type}
         if symbol:
             body["symbol"] = self._format_symbol(symbol)
-        return self._private_request("POST", "/api/v2/mix/order/cancel-all-orders", body=body)
+        if margin_coin:
+            body["marginCoin"] = margin_coin
+        return self._private_request(
+            "POST", "/api/v2/mix/order/cancel-all-orders", body=body
+        )
 
     def close_position(
         self,

--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -95,9 +95,11 @@ def find_trade_positions(
         eslow = ema_func(closes, ema_slow_n)
         signal = cross_func(efull[-1], eslow[-1], efull[-2], eslow[-2])
         if signal == 1:
-            results.append({"symbol": symbol, "signal": "long", "price": float(info.get("lastPrice", 0.0))})
+            price_str = info.get("lastPr") or info.get("lastPrice") or 0.0
+            results.append({"symbol": symbol, "signal": "long", "price": float(price_str)})
         elif signal == -1:
-            results.append({"symbol": symbol, "signal": "short", "price": float(info.get("lastPrice", 0.0))})
+            price_str = info.get("lastPr") or info.get("lastPrice") or 0.0
+            results.append({"symbol": symbol, "signal": "short", "price": float(price_str)})
     return results
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -264,13 +264,14 @@ def test_cancel_all_endpoint(monkeypatch):
 
     monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
 
-    client.cancel_all("BTCUSDT_UMCBL")
+    client.cancel_all("BTCUSDT_UMCBL", margin_coin="USDT")
 
     assert called["method"] == "POST"
     assert called["path"] == "/api/v2/mix/order/cancel-all-orders"
     assert called["body"] == {
         "productType": "USDT-FUTURES",
         "symbol": "BTCUSDT",
+        "marginCoin": "USDT",
     }
 
 


### PR DESCRIPTION
## Summary
- Send `marginCoin` when cancelling all orders
- Interpret Bitget ticker responses using `code` and `lastPr`
- Update helpers to parse `lastPr` values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6f4c52e9083278ae592edf6a885a5