### PR TITLE
Avoid network calls in paper trading

### DIFF
--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -269,6 +269,8 @@ class BitgetFuturesClient:
         return self._private_request("GET", "/api/v2/mix/account/accounts")
 
     def get_positions(self, product_type: Optional[str] = None) -> Dict[str, Any]:
+        if self.paper_trade:
+            return {"success": True, "code": 0, "data": []}
         data = self._private_request(
             "GET",
             "/api/v2/mix/position/all-position",
@@ -290,6 +292,8 @@ class BitgetFuturesClient:
         return data
 
     def get_open_orders(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        if self.paper_trade:
+            return {"success": True, "code": 0, "data": []}
         params: Dict[str, Any] = {"productType": self.product_type}
         if symbol:
             params["symbol"] = self._format_symbol(symbol)
@@ -420,6 +424,11 @@ class BitgetFuturesClient:
         return self._private_request("POST", "/api/v2/mix/order/place", body=body)
 
     def cancel_order(self, order_ids: List[int]) -> Dict[str, Any]:
+        if self.paper_trade:
+            logging.info(
+                "PAPER_TRADE=True -> annulation simulée: order_ids=%s", order_ids
+            )
+            return {"success": True, "code": 0}
         return self._private_request(
             "POST", "/api/v2/mix/order/cancel-order", body={"orderIds": order_ids}
         )
@@ -429,6 +438,11 @@ class BitgetFuturesClient:
         symbol: Optional[str] = None,
         margin_coin: Optional[str] = None,
     ) -> Dict[str, Any]:
+        if self.paper_trade:
+            logging.info(
+                "PAPER_TRADE=True -> annulation simulée de tous les ordres"
+            )
+            return {"success": True, "code": 0}
         body = {"productType": self.product_type}
         if symbol:
             body["symbol"] = self._format_symbol(symbol)
@@ -457,6 +471,12 @@ class BitgetFuturesClient:
             Optional side (``"long"``/``"short"``) to close when ``size`` is
             specified. If not provided the exchange will infer it.
         """
+
+        if self.paper_trade:
+            logging.info(
+                "PAPER_TRADE=True -> fermeture simulée de la position %s", symbol
+            )
+            return {"success": True, "code": 0}
 
         body = {"symbol": self._format_symbol(symbol)}
         if size is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -194,7 +194,7 @@ def test_get_kline_query_params(monkeypatch):
 
 
 def test_get_open_orders_endpoint(monkeypatch):
-    client = BitgetFuturesClient("key", "secret", "https://test")
+    client = BitgetFuturesClient("key", "secret", "https://test", paper_trade=False)
 
     called = {}
 
@@ -252,7 +252,7 @@ def test_get_contract_detail_endpoint(monkeypatch):
 
 
 def test_cancel_all_endpoint(monkeypatch):
-    client = BitgetFuturesClient("key", "secret", "https://test")
+    client = BitgetFuturesClient("key", "secret", "https://test", paper_trade=False)
 
     called = {}
 
@@ -273,6 +273,41 @@ def test_cancel_all_endpoint(monkeypatch):
         "symbol": "BTCUSDT",
         "marginCoin": "USDT",
     }
+
+
+def test_get_open_orders_paper_trade(monkeypatch):
+    client = BitgetFuturesClient("key", "secret", "https://test", paper_trade=True)
+
+    called = {"count": 0}
+
+    def fake_private(*a, **k):
+        called["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
+
+    resp = client.get_open_orders("BTCUSDT_UMCBL")
+
+    assert resp["success"] is True
+    assert resp["data"] == []
+    assert called["count"] == 0
+
+
+def test_cancel_all_paper_trade(monkeypatch):
+    client = BitgetFuturesClient("key", "secret", "https://test", paper_trade=True)
+
+    called = {"count": 0}
+
+    def fake_private(*a, **k):
+        called["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
+
+    resp = client.cancel_all("BTCUSDT_UMCBL", margin_coin="USDT")
+
+    assert resp["success"] is True
+    assert called["count"] == 0
 
 
 def test_get_kline_transforms_data(monkeypatch):


### PR DESCRIPTION
## Summary
- Skip Bitget API requests in paper trading mode for position/order queries and cancellations
- Add tests covering simulated behaviour when paper trading

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6f6f6acf483278f316505abc85114