### PR TITLE
feat: send top crypto list on startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -273,7 +273,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     notify("bot_started")
     try:
-        send_selected_pairs(client, top_n=20, tg_bot=tg_bot)
+        update(client, top_n=20, tg_bot=tg_bot)
     except Exception as exc:  # pragma: no cover - network
         logging.error("Erreur sélection paires: %s", exc)
     if tg_bot:


### PR DESCRIPTION
## Summary
- call update during initialization so the 20 most active crypto pairs are sent immediately

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6f8df681c8327a0fea7f3e35c6f05