### PR TITLE
Improve Bitget client diagnostics

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,7 @@ log_event = _noop_event
 
 def check_config() -> None:
     """Log only missing critical environment variables."""
-    critical = {"BITGET_ACCESS_KEY", "BITGET_SECRET_KEY"}
+    critical = {"BITGET_ACCESS_KEY", "BITGET_SECRET_KEY", "BITGET_PASSPHRASE"}
     for key in critical:
         val = os.getenv(key)
         if not val or val in {"", "A_METTRE", "B_METTRE"}:


### PR DESCRIPTION
## Summary
- surface HTTP error details from Bitget API responses
- check BITGET_PASSPHRASE env var during startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a701ffd00883279b5e607ab10e9b0b