### PR TITLE
Log partial Bitget credentials at startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -57,6 +57,8 @@ def check_config() -> None:
         val = os.getenv(key)
         if not val or val in {"", "A_METTRE", "B_METTRE"}:
             logging.warning("%s manquante", key)
+        else:
+            logging.info("%s: %s*****", key, val[:5])
 
 
 class BitgetFuturesClient(_BaseBitgetFuturesClient):


### PR DESCRIPTION
## Summary
- Display the first five characters of Bitget API credentials when launching the bot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a70bccfe64832795934c204e540b4f