### PR TITLE
Fix Bitget signature prehash with query parameters

### DIFF
--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -230,7 +230,6 @@ class BitgetFuturesClient:
         body: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         method = method.upper()
-        url = f"{self.base}{path}"
         ts = self._ms()
 
         if method in ("GET", "DELETE"):
@@ -238,16 +237,17 @@ class BitgetFuturesClient:
             req_path = path + (f"?{qs}" if qs else "")
             sig = self._sign(f"{ts}{method}{req_path}")
             headers = self._headers(sig, ts)
-            r = self.requests.request(method, url, params=params, headers=headers, timeout=20)
+            url = f"{self.base}{req_path}"
+            r = self.requests.request(method, url, headers=headers, timeout=20)
         elif method == "POST":
             qs = self._urlencode_sorted(params or {})
             req_path = path + (f"?{qs}" if qs else "")
             body_str = json.dumps(body or {}, separators=(",", ":"), ensure_ascii=False)
             sig = self._sign(f"{ts}{method}{req_path}{body_str}")
             headers = self._headers(sig, ts)
+            url = f"{self.base}{req_path}"
             r = self.requests.post(
                 url,
-                params=params,
                 data=body_str.encode("utf-8"),
                 headers=headers,
                 timeout=20,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,10 +18,9 @@ def test_private_request_get_signature(monkeypatch):
 
     called = {}
 
-    def fake_request(method, url, params=None, headers=None, timeout=None):
+    def fake_request(method, url, headers=None, timeout=None):
         called["method"] = method
         called["url"] = url
-        called["params"] = params
         called["headers"] = headers
 
         class Resp:
@@ -46,7 +45,7 @@ def test_private_request_get_signature(monkeypatch):
     assert called["headers"]["ACCESS-KEY"] == "key"
     assert called["headers"]["ACCESS-TIMESTAMP"] == "1000"
     assert called["headers"]["ACCESS-RECV-WINDOW"] == "30"
-    assert called["params"] == {"b": "2", "a": "1"}
+    assert called["url"] == "https://test/api/test?a=1&b=2"
 
 
 def test_private_request_post_signature(monkeypatch):
@@ -55,9 +54,8 @@ def test_private_request_post_signature(monkeypatch):
 
     called = {}
 
-    def fake_post(url, params=None, data=None, headers=None, timeout=None):
+    def fake_post(url, data=None, headers=None, timeout=None):
         called["url"] = url
-        called["params"] = params
         called["data"] = data
         called["headers"] = headers
 
@@ -83,8 +81,8 @@ def test_private_request_post_signature(monkeypatch):
     assert called["headers"]["ACCESS-KEY"] == "key"
     assert called["headers"]["ACCESS-TIMESTAMP"] == "1000"
     assert called["headers"]["ACCESS-RECV-WINDOW"] == "30"
-    assert called["params"] is None
     assert called["data"].decode("utf-8") == body
+    assert called["url"] == "https://test/api/test"
 
 
 def test_private_request_http_error(monkeypatch):


### PR DESCRIPTION
## Summary
- fix Bitget futures client to sign request path with query string
- adjust tests for new signing behaviour
- update helper script signing utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a71561b0f083279e05cc4cfc50243a