### PR TITLE
Fix Bitget cancel_all to use request body

### DIFF
--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -481,15 +481,15 @@ class BitgetFuturesClient:
                 "PAPER_TRADE=True -> annulation simulée de tous les ordres"
             )
             return {"success": True, "code": 0}
-        params = {"productType": self.product_type}
+        body = {"productType": self.product_type}
         if symbol:
-            params["symbol"] = self._format_symbol(symbol)
+            body["symbol"] = self._format_symbol(symbol)
         if margin_coin is None:
             margin_coin = _DEFAULT_MARGIN_COIN.get(self.product_type)
         if margin_coin:
-            params["marginCoin"] = margin_coin
+            body["marginCoin"] = margin_coin
         return self._private_request(
-            "POST", "/api/v2/mix/order/cancel-all-orders", params=params
+            "POST", "/api/v2/mix/order/cancel-all-orders", body=body
         )
 
     def close_position(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -269,12 +269,12 @@ def test_cancel_all_endpoint(monkeypatch):
 
     assert called["method"] == "POST"
     assert called["path"] == "/api/v2/mix/order/cancel-all-orders"
-    assert called["params"] == {
+    assert called["params"] is None
+    assert called["body"] == {
         "productType": "USDT-FUTURES",
         "symbol": "BTCUSDT",
         "marginCoin": "USDT",
     }
-    assert called["body"] is None
 
 
 def test_get_open_orders_paper_trade(monkeypatch):


### PR DESCRIPTION
## Summary
- send cancel-all-orders parameters in request body
- adjust tests for new body-based request

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a717c38f10832781f8adf1da228b46