### PR TITLE
Avoid logging API key prefixes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -57,8 +57,6 @@ def check_config() -> None:
         val = os.getenv(key)
         if not val or val in {"", "A_METTRE", "B_METTRE"}:
             logging.warning("%s manquante", key)
-        else:
-            logging.info("%s: %s*****", key, val[:5])
 
 
 class BitgetFuturesClient(_BaseBitgetFuturesClient):

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -12,3 +12,12 @@ def test_check_config_only_logs_critical_missing(monkeypatch, caplog):
     assert any("BITGET_ACCESS_KEY" in m for m in messages)
     assert any("BITGET_SECRET_KEY" in m for m in messages)
     assert all("NOTIFY_URL" not in m for m in messages)
+
+
+def test_check_config_does_not_log_present_keys(monkeypatch, caplog):
+    monkeypatch.setenv("BITGET_ACCESS_KEY", "abcdef")
+    monkeypatch.setenv("BITGET_SECRET_KEY", "abcdef")
+    monkeypatch.setenv("BITGET_PASSPHRASE", "abcdef")
+    with caplog.at_level(logging.INFO):
+        check_config()
+    assert caplog.records == []


### PR DESCRIPTION
## Summary
- stop logging partial API key values in `check_config`
- add regression test ensuring no logs when keys are present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a717b1a53c8327a1763cb371fabb1a