### PR TITLE
Handle empty cancel responses and improve equity lookup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -192,7 +192,15 @@ def main(argv: Optional[List[str]] = None) -> None:
     try:
         for row in assets.get("data", []):
             if row.get("currency") == "USDT":
-                equity_usdt = float(row.get("equity", 0.0))
+                for key in ("equity", "usdtEquity", "available", "cashBalance"):
+                    val = row.get(key)
+                    try:
+                        if val is not None:
+                            equity_usdt = float(val)
+                    except (TypeError, ValueError):
+                        equity_usdt = 0.0
+                    if equity_usdt > 0:
+                        break
                 break
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- Avoid logging errors when cancel-all returns `22001` (no open orders)
- Extract USDT equity from several possible fields for more reliable balance detection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a71964418883279c1ea765ab49b4f1