### PR TITLE
Fix asset currency detection for Bitget futures

### DIFF
--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -313,9 +313,16 @@ class BitgetFuturesClient:
             margin_coin = _DEFAULT_MARGIN_COIN.get(self.product_type)
         if margin_coin:
             params["marginCoin"] = margin_coin
-        return self._private_request(
+        data = self._private_request(
             "GET", "/api/v2/mix/account/accounts", params=params
         )
+        try:
+            for row in data.get("data", []):
+                if "currency" not in row and row.get("marginCoin"):
+                    row["currency"] = row["marginCoin"]
+        except Exception:  # pragma: no cover - best effort
+            pass
+        return data
 
     def get_positions(self, product_type: Optional[str] = None) -> Dict[str, Any]:
         if self.paper_trade:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -114,6 +114,22 @@ def test_get_assets_paper_trade():
     assert usdt and usdt["equity"] == 100.0
 
 
+def test_get_assets_margincoin_alias(monkeypatch):
+    client = BitgetFuturesClient("key", "secret", "https://test", paper_trade=False)
+
+    def fake_private(self, method, path, params=None, body=None):
+        assert method == "GET"
+        return {
+            "success": True,
+            "data": [{"marginCoin": "USDT", "equity": "50"}],
+        }
+
+    monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
+
+    assets = client.get_assets(margin_coin="USDT")
+    assert assets["data"][0]["currency"] == "USDT"
+
+
 def test_http_client_context_manager(monkeypatch):
     import sys
     import importlib


### PR DESCRIPTION
## Summary
- map `marginCoin` to `currency` in `get_assets` so equity detection works with live API responses
- test asset retrieval when only `marginCoin` is returned

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a71affc76c8327a448e30c7801edf5