### PR TITLE
chore: stop sending pair list updates to Telegram

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -152,9 +152,7 @@ def find_trade_positions(
     )
 
 
-def send_selected_pairs(
-    client: Any, top_n: int = 20, tg_bot: Any | None = None
-) -> Dict[str, str]:
+def send_selected_pairs(client: Any, top_n: int = 20) -> Dict[str, str]:
     """Send the selected trading pairs and return the payload."""
     payload = _pairs.send_selected_pairs(
         client,
@@ -162,14 +160,12 @@ def send_selected_pairs(
         select_fn=filter_trade_pairs,
         notify_fn=notify,
     )
-    if tg_bot and payload:
-        tg_bot.send(_format_text("pair_list", payload))
     return payload
 
 
-def update(client: Any, top_n: int = 20, tg_bot: Any | None = None) -> Dict[str, str]:
+def update(client: Any, top_n: int = 20) -> Dict[str, str]:
     """Send a fresh list of pairs to reflect current market conditions."""
-    payload = send_selected_pairs(client, top_n=top_n, tg_bot=tg_bot)
+    payload = send_selected_pairs(client, top_n=top_n)
     text = _format_text("pair_list", payload)
     logging.info(text)
     return payload
@@ -340,7 +336,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     notify("bot_started")
     try:
-        update(client, top_n=20, tg_bot=tg_bot)
+        update(client, top_n=20)
     except Exception as exc:  # pragma: no cover - network
         logging.error("Erreur sélection paires: %s", exc)
     if tg_bot:
@@ -358,7 +354,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         now = time.time()
         if now >= next_update:
             try:
-                update(client, top_n=20, tg_bot=tg_bot)
+                update(client, top_n=20)
             except Exception as exc:  # pragma: no cover - network
                 logging.error("Erreur update marché: %s", exc)
             next_update = now + 60

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -126,13 +126,11 @@ def _format_text(event: str, payload: Dict[str, Any] | None = None) -> str:
 
 
 def notify(event: str, payload: Dict[str, Any] | None = None) -> None:
-    """Send an event payload to configured endpoints.
+    """Send an event payload to a configured HTTP endpoint.
 
-    Notifications can be delivered via a generic HTTP endpoint defined by
-    ``NOTIFY_URL`` and/or directly to Telegram when ``TELEGRAM_BOT_TOKEN`` and
-    ``TELEGRAM_CHAT_ID`` are provided. Missing configuration for one notifier
-    doesn't affect the others. Network errors are logged but otherwise ignored
-    so they don't interrupt the bot's execution.
+    Notifications are delivered via a generic webhook defined by
+    ``NOTIFY_URL``. Network errors are logged but otherwise ignored so they do
+    not interrupt the bot's execution.
     """
 
     data = {"event": event}
@@ -146,14 +144,3 @@ def notify(event: str, payload: Dict[str, Any] | None = None) -> None:
             requests.post(url, json=data, timeout=5)
         except Exception as exc:  # pragma: no cover - best effort only
             logging.error("Notification error for %s: %s", event, exc)
-
-    # Telegram bot notification
-    token = os.getenv("TELEGRAM_BOT_TOKEN")
-    chat_id = os.getenv("TELEGRAM_CHAT_ID")
-    if token and chat_id:
-        tg_url = f"https://api.telegram.org/bot{token}/sendMessage"
-        tg_payload = {"chat_id": chat_id, "text": _format_text(event, payload)}
-        try:
-            requests.post(tg_url, json=tg_payload, timeout=5)
-        except Exception as exc:  # pragma: no cover - best effort only
-            logging.error("Telegram notification error for %s: %s", event, exc)

--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -116,8 +116,7 @@ class TelegramBot:
 
     def update_pairs(self) -> None:
         from bot import update as _update  # lazy import to avoid cycle
-
-        _update(self.client, top_n=20, tg_bot=self)
+        _update(self.client, top_n=20)
 
     # ------------------------------------------------------------------
     def _api_url(self, method: str) -> str:

--- a/tests/test_bot_update.py
+++ b/tests/test_bot_update.py
@@ -3,13 +3,13 @@ import bot
 
 
 def test_update_displays_pairs(monkeypatch, caplog):
-    def fake_send(client, top_n=20, tg_bot=None):
-        assert (client, top_n, tg_bot) == ("cli", 5, "tg")
+    def fake_send(client, top_n=20):
+        assert (client, top_n) == ("cli", 5)
         return {"green": "BTC", "orange": "ETH", "red": "XRP"}
 
     monkeypatch.setattr(bot, "send_selected_pairs", fake_send)
     with caplog.at_level(logging.INFO):
-        payload = bot.update("cli", top_n=5, tg_bot="tg")
+        payload = bot.update("cli", top_n=5)
     assert payload["green"] == "BTC"
     assert "BTC" in caplog.text and "ETH" in caplog.text and "XRP" in caplog.text
 


### PR DESCRIPTION
## Summary
- drop Telegram delivery in notifier and pair list update logic
- adjust tests for notification changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a721da65a48327a207a7046953e9d7