### PR TITLE
fix: use correct bitget order endpoint

### DIFF
--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -477,7 +477,7 @@ class BitgetFuturesClient:
         if position_mode is not None:
             body["positionMode"] = int(position_mode)
 
-        return self._private_request("POST", "/api/v2/mix/order/place", body=body)
+        return self._private_request("POST", "/api/v2/mix/order/place-order", body=body)
 
     def cancel_order(self, order_ids: List[int]) -> Dict[str, Any]:
         if self.paper_trade:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -331,6 +331,27 @@ def test_cancel_all_endpoint(monkeypatch):
     }
 
 
+def test_place_order_endpoint(monkeypatch):
+    client = BitgetFuturesClient("key", "secret", "https://test", paper_trade=False)
+
+    called = {}
+
+    def fake_private(self, method, path, params=None, body=None):
+        called["method"] = method
+        called["path"] = path
+        called["body"] = body
+        return {"success": True}
+
+    monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
+
+    resp = client.place_order("BTCUSDT_UMCBL", side=1, vol=1, order_type=1)
+
+    assert resp["success"] is True
+    assert called["method"] == "POST"
+    assert called["path"] == "/api/v2/mix/order/place-order"
+    assert called["body"]["symbol"] == "BTCUSDT"
+
+
 def test_get_open_orders_paper_trade(monkeypatch):
     client = BitgetFuturesClient("key", "secret", "https://test", paper_trade=True)
 


### PR DESCRIPTION
## Summary
- fix Bitget futures client to call `/api/v2/mix/order/place-order` when submitting orders
- add regression test for order placement path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a724881db4832795b2b35e99da1701