### PR TITLE
feat: move shutdown button to main menu

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -52,12 +52,12 @@ class TelegramBot:
             [{"text": "Positions ouvertes", "callback_data": "positions"}],
             [{"text": "Update Cryptos", "callback_data": "update"}],
             [{"text": "Réglages", "callback_data": "settings"}],
+            [{"text": "Arrêt bot", "callback_data": "shutdown"}],
         ]
         self.settings_keyboard = [
             [{"text": "Stop trade", "callback_data": "stop"}],
             [{"text": "Réglage risk", "callback_data": "risk"}],
             [{"text": "Reset risk", "callback_data": "reset_risk"}],
-            [{"text": "Arrêt bot", "callback_data": "shutdown"}],
             [{"text": "Reset total", "callback_data": "reset_all"}],
             [{"text": "Retour", "callback_data": "back"}],
         ]
@@ -283,7 +283,7 @@ class TelegramBot:
 
         if data == "shutdown":
             self.stop_requested = True
-            return "Arrêt du bot demandé", self.settings_keyboard
+            return "Arrêt du bot demandé", self.main_keyboard
 
         if data == "back":
             return self._menu_text(session_pnl), self.main_keyboard

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -158,7 +158,7 @@ def test_shutdown_bot():
     resp, kb = bot.handle_callback("shutdown", 0.0)
     assert "arrêt" in resp.lower()
     assert bot.stop_requested is True
-    assert kb == bot.settings_keyboard
+    assert kb == bot.main_keyboard
 
 
 def test_start_sends_menu():


### PR DESCRIPTION
## Summary
- show "Arrêt bot" button directly in main Telegram bot menu
- adjust shutdown callback to return to main menu
- update tests for new button placement

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7288af4308327bab4eb27132f94dd