### PR TITLE
Format Telegram numbers to two decimals

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -106,8 +106,8 @@ class TelegramBot:
                     equity = 0.0
                 break
         return (
-            f"Solde: {equity} USDT\n"
-            f"PnL session: {session_pnl} USDT\n"
+            f"Solde: {equity:.2f} USDT\n"
+            f"PnL session: {session_pnl:.2f} USDT\n"
             "Choisissez une option:"
         )
 
@@ -203,7 +203,7 @@ class TelegramBot:
                         equity = 0.0
                     break
 
-            return f"Solde: {equity} USDT", self.main_keyboard
+            return f"Solde: {equity:.2f} USDT", self.main_keyboard
         if data == "positions":
             pos = self.client.get_positions() or {}
             lines = []
@@ -218,14 +218,14 @@ class TelegramBot:
                 pnl_pct = p.get("pnl_pct")
                 line = f"{base} {side} {vol}"
                 if pnl is not None and pnl_pct is not None:
-                    line += f"\nPnL: {pnl} USDT ({pnl_pct}%)"
+                    line += f"\nPnL: {pnl:.2f} USDT ({pnl_pct:.2f}%)"
                 lines.append(line)
             if not lines:
 
                 return "Aucune position ouverte", self.main_keyboard
             return "Positions:\n" + "\n".join(lines), self.main_keyboard
         if data == "pnl":
-            return f"PnL session: {session_pnl} USDT", self.main_keyboard
+            return f"PnL session: {session_pnl:.2f} USDT", self.main_keyboard
         if data == "risk":
             return "Choisissez le niveau de risque:", self.risk_keyboard
         if data == "settings":

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -95,7 +95,7 @@ def test_handle_positions_zero_pnl():
 
     bot.client.get_positions = zero_positions
     resp, _ = bot.handle_callback("positions", 0.0)
-    assert "PnL: 0.0 USDT" in resp
+    assert "PnL: 0.00 USDT" in resp
 
 
 
@@ -103,7 +103,7 @@ def test_handle_pnl():
     bot = make_bot()
     resp, _ = bot.handle_callback("pnl", 5.0)
 
-    assert "5.0" in resp
+    assert "5.00" in resp
 
 
 def test_handle_risk_change():


### PR DESCRIPTION
## Summary
- format balance, session PnL and position PnL with two decimals in Telegram bot
- adjust tests for the new formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a728b7f3508327afd4986e3c7dbef6