### PR TITLE
Stop sending pair listing to Telegram

### DIFF
--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -149,7 +149,8 @@ def notify(event: str, payload: Dict[str, Any] | None = None) -> None:
     # Telegram notification
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
-    if token and chat_id:
+    # ``pair_list`` notifications are intentionally not forwarded to Telegram
+    if token and chat_id and event != "pair_list":
         text = _format_text(event, payload or {})
         t_url = f"https://api.telegram.org/bot{token}/sendMessage"
         t_payload = {"chat_id": chat_id, "text": text}

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -73,6 +73,23 @@ def test_notify_posts_both(monkeypatch):
     assert "https://api.telegram.org/botabc/sendMessage" in urls
 
 
+def test_notify_skips_telegram_for_pair_list(monkeypatch):
+    calls = []
+
+    def fake_post(url, json=None, timeout=5):
+        calls.append(url)
+
+    monkeypatch.setenv("NOTIFY_URL", "http://example.com")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+    monkeypatch.setattr(notifier.requests, "post", fake_post)
+
+    notifier.notify("pair_list", {"pairs": "BTC"})
+
+    # Only the generic webhook should be called, not Telegram
+    assert calls == ["http://example.com"]
+
+
 def test_format_text_open_position():
     payload = {
         "side": "long",


### PR DESCRIPTION
## Summary
- avoid sending `pair_list` notifications to Telegram
- add regression test to ensure pair listings only hit the generic webhook

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73140f45483279062315eb9a7e533