### PR TITLE
feat: add telegram button for max positions

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -57,6 +57,7 @@ class TelegramBot:
         self.settings_keyboard = [
             [{"text": "Stop trade", "callback_data": "stop"}],
             [{"text": "Réglage risk", "callback_data": "risk"}],
+            [{"text": "Nb positions", "callback_data": "maxpos"}],
             [{"text": "Reset risk", "callback_data": "reset_risk"}],
             [{"text": "Reset total", "callback_data": "reset_all"}],
             [{"text": "Retour", "callback_data": "back"}],
@@ -66,6 +67,18 @@ class TelegramBot:
                 {"text": "🟢", "callback_data": "risk_green"},
                 {"text": "🟠", "callback_data": "risk_orange"},
                 {"text": "🔴", "callback_data": "risk_red"},
+            ],
+            [{"text": "Retour", "callback_data": "back"}],
+        ]
+        self.maxpos_keyboard = [
+            [
+                {"text": "1", "callback_data": "maxpos_1"},
+                {"text": "2", "callback_data": "maxpos_2"},
+                {"text": "3", "callback_data": "maxpos_3"},
+            ],
+            [
+                {"text": "4", "callback_data": "maxpos_4"},
+                {"text": "5", "callback_data": "maxpos_5"},
             ],
             [{"text": "Retour", "callback_data": "back"}],
         ]
@@ -230,6 +243,8 @@ class TelegramBot:
             return "Choisissez le niveau de risque:", self.risk_keyboard
         if data == "settings":
             return "Réglages:", self.settings_keyboard
+        if data == "maxpos":
+            return "Choisissez le nombre de positions:", self.maxpos_keyboard
         if data == "reset_risk":
             try:
                 self.risk_mgr.reset_day()
@@ -253,6 +268,17 @@ class TelegramBot:
                 self.config["RISK_LEVEL"] = lvl
                 return f"Niveau de risque réglé sur {lvl}", self.main_keyboard
             return "Niveau de risque inchangé", self.main_keyboard
+
+        if data.startswith("maxpos_"):
+            try:
+                lvl = int(data.split("_", 1)[1])
+            except Exception:
+                lvl = None
+            if lvl:
+                self.config["MAX_POSITIONS"] = lvl
+                self.risk_mgr.max_positions = lvl
+                return f"Nombre de positions réglé sur {lvl}", self.main_keyboard
+            return "Nombre de positions inchangé", self.main_keyboard
 
         if data == "reset_all":
             try:

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -36,6 +36,7 @@ class DummyRiskMgr:
 
     def __init__(self):
         self.reset_called = False
+        self.max_positions = 1
 
     def reset_day(self):
         self.reset_called = True
@@ -53,7 +54,7 @@ class DummyRequests:
 
 
 def make_bot(config=None, requests_module=None):
-    cfg = {"RISK_LEVEL": 2}
+    cfg = {"RISK_LEVEL": 2, "MAX_POSITIONS": 1}
     if config:
         cfg.update(config)
     if requests_module is None:
@@ -191,6 +192,18 @@ def test_update_button(monkeypatch):
     resp, kb = bot.handle_callback("update", 0.0)
     assert called["called"] is True
     assert "mise à jour" in resp.lower()
+    assert kb == bot.main_keyboard
+
+
+def test_maxpos_menu_and_change():
+    bot = make_bot()
+    resp, kb = bot.handle_callback("maxpos", 0.0)
+    assert "nombre" in resp.lower()
+    assert kb == bot.maxpos_keyboard
+    resp, kb = bot.handle_callback("maxpos_3", 0.0)
+    assert "3" in resp
+    assert bot.config["MAX_POSITIONS"] == 3
+    assert bot.risk_mgr.max_positions == 3
     assert kb == bot.main_keyboard
 
 


### PR DESCRIPTION
## Summary
- add Telegram settings button to configure max simultaneous positions
- support updating risk manager and config from Telegram
- test Telegram max position controls

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7422e4a008327b283a0626394a926