### PR TITLE
Prefer available balance for position sizing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -86,7 +86,16 @@ class BitgetFuturesClient(_BaseBitgetFuturesClient):
         for a in rows:
             cur = a.get("marginCoin") or a.get("currency") or "USDT"
             try:
-                eq = float(a.get("equity", a.get("available", 0)) or 0)
+                eq = float(
+                    a.get(
+                        "available",
+                        a.get(
+                            "cashBalance",
+                            a.get("equity", a.get("usdtEquity", 0)),
+                        ),
+                    )
+                    or 0
+                )
             except Exception:
                 eq = 0.0
             norm.append({**a, "currency": cur, "equity": eq})
@@ -239,28 +248,38 @@ def main(argv: Optional[List[str]] = None) -> None:
         contract_detail = {"success": False, "code": 404}
     log_event("contract_detail", contract_detail)
 
-    try:
-        assets = client.get_assets()
-    except requests.RequestException as exc:  # pragma: no cover - network issues
-        logging.error("Erreur récupération assets: %s", exc)
-        assets = {"success": False, "data": []}
-    log_event("assets", assets)
-    equity_usdt = 0.0
-    try:
+    def _fetch_equity() -> float:
+        """Retrieve available USDT balance from the exchange.
+
+        Bitget returns several balance metrics; ``available``/``cashBalance``
+        represent free margin and are therefore preferred over total equity.
+        ``0.0`` is returned when no usable balance can be obtained.
+        """
+
+        try:
+            assets = client.get_assets()
+            log_event("assets", assets)
+        except requests.RequestException as exc:  # pragma: no cover - network issues
+            logging.error("Erreur récupération assets: %s", exc)
+            return 0.0
+
         for row in assets.get("data", []):
             if row.get("currency") == "USDT":
-                for key in ("equity", "usdtEquity", "available", "cashBalance"):
+                for key in ("available", "cashBalance", "equity", "usdtEquity"):
                     val = row.get(key)
                     try:
                         if val is not None:
-                            equity_usdt = float(val)
+                            eq = float(val)
+                        else:
+                            continue
                     except (TypeError, ValueError):
-                        equity_usdt = 0.0
-                    if equity_usdt > 0:
-                        break
+                        continue
+                    if eq > 0:
+                        return eq
                 break
-    except Exception:
-        pass
+        return 0.0
+
+    equity_usdt = _fetch_equity()
     if equity_usdt <= 0:
         logging.warning(
             "Equity USDT non détectée, fallback symbolique à 100 USDT pour sizing."
@@ -303,7 +322,9 @@ def main(argv: Optional[List[str]] = None) -> None:
             open_type=CONFIG["OPEN_TYPE"],
             leverage=CONFIG["LEVERAGE"],
         )
-        equity_usdt *= 1 + pnl / 100.0
+        new_eq = _fetch_equity()
+        if new_eq > 0:
+            equity_usdt = new_eq
         risk_mgr.record_trade(pnl)
         logging.info("Nouveau risk_pct: %.4f", risk_mgr.risk_pct)
         kill = risk_mgr.kill_switch
@@ -380,6 +401,9 @@ def main(argv: Optional[List[str]] = None) -> None:
             next_update = now + 60
 
         try:
+            new_eq = _fetch_equity()
+            if new_eq > 0:
+                equity_usdt = new_eq
             if current_pos == 0:
                 pairs = filter_trade_pairs(client, top_n=20)
                 signals = find_trade_positions(

--- a/scalp/bitget_client.py
+++ b/scalp/bitget_client.py
@@ -348,12 +348,14 @@ class BitgetFuturesClient:
             for row in data.get("data", []):
                 if "currency" not in row and row.get("marginCoin"):
                     row["currency"] = str(row["marginCoin"]).upper()
-                if "equity" not in row:
-                    for key in ("usdtEquity", "available", "cashBalance"):
-                        val = row.get(key)
-                        if val is not None:
-                            row["equity"] = val
-                            break
+                chosen = None
+                for key in ("available", "cashBalance", "equity", "usdtEquity"):
+                    val = row.get(key)
+                    if val is not None:
+                        chosen = val
+                        break
+                if chosen is not None:
+                    row["equity"] = chosen
                 try:
                     row["equity"] = float(row["equity"])
                 except Exception:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -142,6 +142,29 @@ def test_get_assets_equity_fallback(monkeypatch):
     assert usdt["equity"] == 2.0
 
 
+def test_get_assets_prefers_available(monkeypatch):
+    """When both equity and available are returned, available should win."""
+    client = BitgetFuturesClient("key", "secret", "https://test")
+
+    def fake_private(self, method, path, params=None, body=None):
+        return {
+            "code": "00000",
+            "data": [
+                {
+                    "marginCoin": "USDT",
+                    "equity": "5",
+                    "available": "1",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
+
+    assets = client.get_assets()
+    usdt = assets.get("data", [])[0]
+    assert usdt["equity"] == 1.0
+
+
 def test_get_ticker_normalization(monkeypatch):
     client = BitgetFuturesClient("key", "secret", "https://test")
 


### PR DESCRIPTION
## Summary
- fetch available USDT balance from Bitget and size positions against it
- refresh account equity on every loop and after closing positions
- cover new balance selection logic with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a747ea34148327a2a589e909cb48c8