### PR TITLE
feat: show risk and position info in telegram menu

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -121,6 +121,8 @@ class TelegramBot:
         return (
             f"Solde: {equity:.2f} USDT\n"
             f"PnL session: {session_pnl:.2f} USDT\n"
+            f"Positions max: {self.risk_mgr.max_positions}\n"
+            f"Risque actuel: {self.risk_mgr.risk_pct * 100:.2f}%\n"
             "Choisissez une option:"
         )
 

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -37,6 +37,7 @@ class DummyRiskMgr:
     def __init__(self):
         self.reset_called = False
         self.max_positions = 1
+        self.risk_pct = 0.01
 
     def reset_day(self):
         self.reset_called = True
@@ -168,6 +169,8 @@ def test_start_sends_menu():
     assert req.posts
     text = req.posts[0][1]["text"]
     assert "Solde" in text and "PnL session" in text
+    assert "Positions max" in text
+    assert "Risque actuel" in text
 
 
 def test_settings_menu_and_reset_risk():


### PR DESCRIPTION
## Summary
- display max concurrent positions and current risk percent in Telegram bot menu
- extend Telegram bot tests to cover new menu information

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a749f710fc8327a71eac4e8c53390f