### PR TITLE
Clamp position size to account balance

### DIFF
--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -43,9 +43,23 @@ def compute_position_size(
     notional = equity_usdt * float(risk_pct) * float(leverage)
     if notional <= 0.0:
         return 0
+
     vol = notional / (price * contract_size)
     vol = int(math.floor(vol / vol_unit) * vol_unit)
-    return max(min_vol, vol)
+    vol = max(min_vol, vol)
+
+    margin = price * contract_size * vol / leverage
+    if margin > equity_usdt:
+        vol = int(
+            math.floor(
+                equity_usdt * leverage / (price * contract_size) / vol_unit
+            )
+            * vol_unit
+        )
+        if vol < min_vol:
+            return 0
+
+    return vol
 
 
 def analyse_risque(

--- a/tests/test_compute_position_size.py
+++ b/tests/test_compute_position_size.py
@@ -51,3 +51,25 @@ def test_compute_position_size_invalid_price():
         symbol="BTC_USDT",
     )
     assert vol == 0
+
+
+def test_compute_position_size_respects_equity():
+    contract_detail = {
+        "data": [
+            {
+                "symbol": "BTC_USDT",
+                "contractSize": 1,
+                "volUnit": 1,
+                "minVol": 1,
+            }
+        ]
+    }
+    vol = compute_position_size(
+        contract_detail,
+        equity_usdt=5,
+        price=100,
+        risk_pct=0.01,
+        leverage=10,
+        symbol="BTC_USDT",
+    )
+    assert vol == 0


### PR DESCRIPTION
## Summary
- prevent order volume from exceeding available equity
- add regression test covering insufficient balance scenario

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a74d1b8f688327a317fe35d471eb9b