### PR TITLE
Handle alternative Bitget balance fields

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,6 +189,23 @@ def test_get_assets_zero_available(monkeypatch):
     assert usdt["equity"] == 0.0
 
 
+def test_get_assets_available_balance(monkeypatch):
+    """Support alternative ``availableBalance`` field name."""
+    client = BitgetFuturesClient("key", "secret", "https://test")
+
+    def fake_private(self, method, path, params=None, body=None):
+        return {
+            "code": "00000",
+            "data": [{"marginCoin": "USDT", "availableBalance": "3.5"}],
+        }
+
+    monkeypatch.setattr(BitgetFuturesClient, "_private_request", fake_private)
+
+    assets = client.get_assets()
+    usdt = assets.get("data", [])[0]
+    assert usdt["equity"] == 3.5
+
+
 def test_get_ticker_normalization(monkeypatch):
     client = BitgetFuturesClient("key", "secret", "https://test")
 


### PR DESCRIPTION
## Summary
- Normalize Bitget asset fetching to handle `availableBalance`/`availableMargin`
- Expand equity fetching logic to consider new balance keys
- Test that alternative balance field names are supported

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74fd6fb188327b82aef1088d69512