### PR TITLE
fix: ensure position sizing uses available balance

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,6 +28,7 @@ from scalp.trade_utils import (
     trailing_stop,
     should_scale_in,
     timeout_exit,
+    extract_available_balance,
 )
 from scalp import pairs as _pairs
 from scalp.backtest import backtest_trades  # noqa: F401
@@ -282,36 +283,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             logging.error("Erreur récupération assets: %s", exc)
             return 0.0
 
-        for row in assets.get("data", []):
-            if row.get("currency") == "USDT":
-                # champs possibles suivant les versions de l'API
-                for key in (
-                    "available",
-                    "availableBalance",
-                    "availableMargin",
-                    "cashBalance",
-                ):
-                    val = row.get(key)
-                    if val is None:
-                        continue
-                    try:
-                        eq = float(val)
-                    except (TypeError, ValueError):
-                        continue
-                    return eq if eq > 0 else 0.0
-
-                for key in ("equity", "usdtEquity"):
-                    val = row.get(key)
-                    if val is None:
-                        continue
-                    try:
-                        eq = float(val)
-                    except (TypeError, ValueError):
-                        continue
-                    if eq > 0:
-                        return eq
-                break
-        return 0.0
+        return extract_available_balance(assets)
 
     equity_usdt = _fetch_equity()
     if equity_usdt <= 0:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 from bot import ema, cross, compute_position_size, CONFIG
+from scalp.trade_utils import extract_available_balance
 
 
 def test_ema_basic():
@@ -33,3 +34,31 @@ def test_compute_position_size():
 def test_compute_position_size_missing_symbol():
     with pytest.raises(ValueError):
         compute_position_size({"data": []}, 100.0, 1.0, 0.01, 5)
+
+
+def test_extract_available_balance_fallback():
+    assets = {
+        "data": [
+            {
+                "currency": "USDT",
+                "available": 0,
+                "cashBalance": "150.5",
+                "equity": "200",
+            }
+        ]
+    }
+    assert extract_available_balance(assets) == 150.5
+
+
+def test_extract_available_balance_equity():
+    assets = {
+        "data": [
+            {
+                "currency": "USDT",
+                "available": 0,
+                "availableBalance": 0,
+                "equity": "42",
+            }
+        ]
+    }
+    assert extract_available_balance(assets) == 42.0


### PR DESCRIPTION
## Summary
- add `extract_available_balance` helper to parse Bitget asset payloads
- use helper in bot to consider available USDT balance when sizing positions
- test balance extraction against various field combinations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a753ce47b483279705b0ff869ca9b3