### PR TITLE
Check allowed symbols before listing pairs

### DIFF
--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -141,10 +141,14 @@ def send_selected_pairs(
         return sym, ""
 
     pairs = select_fn(client, top_n=top_n * 3)
+    allowed = {s.split("_")[0].upper() for s in CONFIG.get("ALLOWED_SYMBOLS", [])}
     by_base: Dict[str, Dict[str, Any]] = {}
     for info in pairs:
         sym = info.get("symbol")
         if not sym:
+            continue
+        norm_sym = sym.split("_")[0].upper()
+        if allowed and norm_sym not in allowed:
             continue
         base, quote = split_symbol(sym)
         existing = by_base.get(base)

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -23,12 +23,14 @@ def test_send_selected_pairs(monkeypatch):
         ],
     )
 
+    monkeypatch.setitem(bot.CONFIG, "ALLOWED_SYMBOLS", ["BTCUSDT", "ETHUSDT"])
+
     payload = bot.send_selected_pairs(object(), top_n=4)
 
     assert sent["event"] == "pair_list"
-    assert sent["payload"]["green"] == "WIF"
-    assert sent["payload"]["orange"] == "BTC"
-    assert sent["payload"]["red"] == "DOGE, ETH"
+    assert sent["payload"]["green"] == "BTC"
+    assert sent["payload"]["orange"] == "ETH"
+    assert "red" not in sent["payload"]
     assert payload == sent["payload"]
 
 


### PR DESCRIPTION
## Summary
- ensure pair listings skip symbols outside CONFIG.ALLOWED_SYMBOLS
- adjust tests to reflect filtering of disallowed symbols

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76fb1a68c8327b1da2e4f095f0b41