### PR TITLE
feat: expand pair listing to 40

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -9,8 +9,8 @@ Ce fichier résume les modules et fonctions essentiels afin de recréer le bot d
 - `check_config()` : vérifie la présence des clés API Bitget et journalise un avertissement si elles manquent.
 - `BitgetSpotClient` : sous-classe du client spot Bitget qui injecte `requests` et la fonction `log_event`.
 - `find_trade_positions(client, pairs, interval="1m", ema_fast_n=None, ema_slow_n=None)` : applique la stratégie EMA sur une liste de paires et renvoie les signaux.
-- `send_selected_pairs(client, top_n=20, tg_bot=None)` : sélectionne et notifie les paires les plus actives.
-- `update(client, top_n=20, tg_bot=None)` : rafraîchit la liste des paires et renvoie la charge utile envoyée.
+- `send_selected_pairs(client, top_n=40, tg_bot=None)` : sélectionne et notifie les paires les plus actives.
+- `update(client, top_n=40, tg_bot=None)` : rafraîchit la liste des paires et renvoie la charge utile envoyée.
 - `main(argv=None)` : initialise la configuration, le client, le `RiskManager`, le bot Telegram et exécute la boucle de trading.
 
 ### cli.py
@@ -82,10 +82,10 @@ Ce fichier résume les modules et fonctions essentiels afin de recréer le bot d
 
 ### pairs.py
 - `get_trade_pairs(client)` : récupère toutes les paires via `get_ticker`.
-- `filter_trade_pairs(client, volume_min=5_000_000, max_spread_bps=5, top_n=20)` : filtre par volume/spread.
+- `filter_trade_pairs(client, volume_min=5_000_000, max_spread_bps=5, top_n=40)` : filtre par volume/spread.
 - `select_top_pairs(client, top_n=10, key="volume")` : trie par volume ou autre clé.
 - `find_trade_positions(client, pairs, interval="1m", ema_fast_n=None, ema_slow_n=None, ema_func=ema, cross_func=cross)` : signaux EMA croisement.
-- `send_selected_pairs(client, top_n=20, select_fn=select_top_pairs, notify_fn=notify)` : déduplique USD/USDT/USDC et notifie la liste.
+- `send_selected_pairs(client, top_n=40, select_fn=select_top_pairs, notify_fn=notify)` : déduplique USD/USDT/USDC et notifie la liste.
 - `heat_score(volatility, volume, news=False)` : score combinant volatilite et volume.
 - `select_top_heat_pairs(pairs, top_n=3)` : sélection des paires les plus "chaudes".
 - `decorrelate_pairs(pairs, corr, threshold=0.8, top_n=3)` : choisit des paires peu corrélées.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python bot.py
 
 Le terminal reste silencieux au démarrage sauf en cas d'absence de variables critiques (`BITGET_ACCESS_KEY`, `BITGET_SECRET_KEY`). Les journaux sont écrits dans `logs/` et affichés sur la console. Le bot tourne jusqu'à `Ctrl+C`. Les ouvertures et fermetures de positions sont consignées dans `bot_events.jsonl`.
 
-Lors du démarrage, deux notifications Telegram sont émises : la première affiche « Bot démarré » avec un logo, la seconde « Listing : » suivi des 20 paires sélectionnées classées par couleur (🟢 < 1 min, 🟠 < 10 min, 🔴 > 10 min).
+Lors du démarrage, deux notifications Telegram sont émises : la première affiche « Bot démarré » avec un logo, la seconde « Listing : » suivi des 40 paires sélectionnées classées par couleur (🟢 < 1 min, 🟠 < 10 min, 🔴 > 10 min).
 
 Ensuite, un rappel du marché est envoyé chaque minute et l'interface Telegram propose un bouton « Fermer Bot » pour arrêter proprement l'exécution.
 

--- a/bot.py
+++ b/bot.py
@@ -186,7 +186,7 @@ def find_trade_positions(
     )
 
 
-def send_selected_pairs(client: Any, top_n: int = 20) -> Dict[str, str]:
+def send_selected_pairs(client: Any, top_n: int = 40) -> Dict[str, str]:
     """Send the selected trading pairs and return the payload."""
     payload = _pairs.send_selected_pairs(
         client,
@@ -197,7 +197,7 @@ def send_selected_pairs(client: Any, top_n: int = 20) -> Dict[str, str]:
     return payload
 
 
-def update(client: Any, top_n: int = 20) -> Dict[str, str]:
+def update(client: Any, top_n: int = 40) -> Dict[str, str]:
     """Send a fresh list of pairs to reflect current market conditions."""
     payload = send_selected_pairs(client, top_n=top_n)
     text = _format_text("pair_list", payload)
@@ -405,7 +405,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     notify("bot_started")
     try:
-        update(client, top_n=20)
+        update(client, top_n=40)
     except Exception as exc:  # pragma: no cover - network
         logging.error("Erreur sélection paires: %s", exc)
     if tg_bot:
@@ -423,7 +423,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         now = time.time()
         if now >= next_update:
             try:
-                update(client, top_n=20)
+                update(client, top_n=40)
             except Exception as exc:  # pragma: no cover - network
                 logging.error("Erreur update marché: %s", exc)
             next_update = now + 60
@@ -432,7 +432,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             new_eq = _fetch_equity()
             equity_usdt = new_eq
             if current_pos == 0:
-                pairs = filter_trade_pairs(client, top_n=20)
+                pairs = filter_trade_pairs(client, top_n=40)
                 signals = find_trade_positions(
                     client,
                     pairs,

--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -22,7 +22,7 @@ def filter_trade_pairs(
     *,
     volume_min: float = 5_000_000,
     max_spread_bps: float = 5.0,
-    top_n: int = 20,
+    top_n: int = 40,
 ) -> List[Dict[str, Any]]:
     """Filter pairs by volume and spread."""
     pairs = get_trade_pairs(client)
@@ -105,7 +105,7 @@ def find_trade_positions(
 
 def send_selected_pairs(
     client: Any,
-    top_n: int = 20,
+    top_n: int = 40,
     *,
     select_fn: Callable[[Any, int], List[Dict[str, Any]]] = select_top_pairs,
     notify_fn: Callable[[str, Optional[Dict[str, Any]]], None] = notify,

--- a/scalp/selection/scanner.py
+++ b/scalp/selection/scanner.py
@@ -11,7 +11,7 @@ def scan_pairs(
     volume_min: float = 5_000_000,
     max_spread_bps: float = 5.0,
     min_hourly_vol: float = 0.0,
-    top_n: int = 20,
+    top_n: int = 40,
 ) -> List[Dict[str, Any]]:
     """Return pairs satisfying basic liquidity and volatility filters.
 

--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -131,7 +131,7 @@ class TelegramBot:
 
     def update_pairs(self) -> None:
         from bot import update as _update  # lazy import to avoid cycle
-        _update(self.client, top_n=20)
+        _update(self.client, top_n=40)
 
     # ------------------------------------------------------------------
     def _api_url(self, method: str) -> str:

--- a/tests/test_bot_update.py
+++ b/tests/test_bot_update.py
@@ -3,7 +3,7 @@ import bot
 
 
 def test_update_displays_pairs(monkeypatch, caplog):
-    def fake_send(client, top_n=20):
+    def fake_send(client, top_n=40):
         assert (client, top_n) == ("cli", 5)
         return {"green": "BTC", "orange": "ETH", "red": "XRP"}
 

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -12,7 +12,7 @@ def test_send_selected_pairs(monkeypatch):
     monkeypatch.setattr(
         bot,
         "filter_trade_pairs",
-        lambda client, top_n=60: [
+        lambda client, top_n=120: [
             {"symbol": "WIFUSDT", "volume": 10},
             {"symbol": "WIFUSDT", "volume": 9},
             {"symbol": "BTCUSD", "volume": 8},


### PR DESCRIPTION
## Summary
- expand default pair selection and listing to 40 cryptos
- update Telegram bot, scanner utility, docs and tests for new limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76fc4950c8327abdab95441231a9b