### PR TITLE
feat: list top 40 cryptos

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -83,7 +83,7 @@ Ce fichier résume les modules et fonctions essentiels afin de recréer le bot d
 ### pairs.py
 - `get_trade_pairs(client)` : récupère toutes les paires via `get_ticker`.
 - `filter_trade_pairs(client, volume_min=5_000_000, max_spread_bps=5, top_n=40)` : filtre par volume/spread.
-- `select_top_pairs(client, top_n=10, key="volume")` : trie par volume ou autre clé.
+- `select_top_pairs(client, top_n=40, key="volume")` : trie par volume ou autre clé.
 - `find_trade_positions(client, pairs, interval="1m", ema_fast_n=None, ema_slow_n=None, ema_func=ema, cross_func=cross)` : signaux EMA croisement.
 - `send_selected_pairs(client, top_n=40, select_fn=select_top_pairs, notify_fn=notify)` : déduplique USD/USDT/USDC et notifie la liste.
 - `heat_score(volatility, volume, news=False)` : score combinant volatilite et volume.

--- a/scalp/pairs.py
+++ b/scalp/pairs.py
@@ -54,7 +54,7 @@ def filter_trade_pairs(
     return eligible[:top_n]
 
 
-def select_top_pairs(client: Any, top_n: int = 10, key: str = "volume") -> List[Dict[str, Any]]:
+def select_top_pairs(client: Any, top_n: int = 40, key: str = "volume") -> List[Dict[str, Any]]:
     """Return ``top_n`` pairs sorted by ``key``."""
     pairs = get_trade_pairs(client)
 

--- a/tests/test_pair_selection.py
+++ b/tests/test_pair_selection.py
@@ -32,6 +32,18 @@ def test_select_top_pairs():
     assert [p["symbol"] for p in top] == ["B", "C"]
 
 
+def test_select_top_pairs_default_count():
+    class Client:
+        def get_ticker(self, symbol=None):
+            data = []
+            for i in range(100):
+                data.append({"symbol": str(i), "volume": str(i)})
+            return {"success": True, "data": data}
+
+    top = bot.select_top_pairs(Client())
+    assert len(top) == 40
+
+
 def test_filter_trade_pairs():
     class Client:
         def get_ticker(self, symbol=None):


### PR DESCRIPTION
## Summary
- list the 40 most active trading pairs by default
- document the new default selection count
- add unit test covering default pair selection length

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a774626bcc8327b656bf6ff7004385