### PR TITLE
Hide pair list details in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python bot.py
 
 Le terminal reste silencieux au démarrage sauf en cas d'absence de variables critiques (`BITGET_ACCESS_KEY`, `BITGET_SECRET_KEY`). Les journaux sont écrits dans `logs/` et affichés sur la console. Le bot tourne jusqu'à `Ctrl+C`. Les ouvertures et fermetures de positions sont consignées dans `bot_events.jsonl`.
 
-Lors du démarrage, deux notifications Telegram sont émises : la première affiche « Bot démarré » avec un logo, la seconde « Listing : » suivi des 40 paires sélectionnées classées par couleur (🟢 < 1 min, 🟠 < 10 min, 🔴 > 10 min).
+Lors du démarrage, deux notifications Telegram sont émises : la première affiche « Bot démarré » avec un logo, la seconde « Listing ok » sans détailler les paires sélectionnées.
 
 Ensuite, un rappel du marché est envoyé chaque minute et l'interface Telegram propose un bouton « Fermer Bot » pour arrêter proprement l'exécution.
 

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -93,21 +93,13 @@ def _format_position_event(event: str, payload: Dict[str, Any]) -> str:
 
 
 def _format_pair_list(payload: Dict[str, Any]) -> str:
-    """Format the pair list payload."""
-    green = payload.get("green")
-    orange = payload.get("orange")
-    red = payload.get("red")
-    if green or orange or red:
-        lines = ["Listing :"]
-        if green:
-            lines.append(f"🟢 {green}")
-        if orange:
-            lines.append(f"🟠 {orange}")
-        if red:
-            lines.append(f"🔴 {red}")
-        return "\n".join(lines)
-    pairs = payload.get("pairs", "")
-    return f"Listing : {pairs}"
+    """Format the pair list payload.
+
+    The detailed pair listing is intentionally hidden from terminal output to
+    reduce noise. Only an acknowledgement message is returned.
+    """
+
+    return "Listing ok"
 
 
 def _format_generic(event: str, payload: Dict[str, Any]) -> str:

--- a/tests/test_bot_update.py
+++ b/tests/test_bot_update.py
@@ -11,5 +11,5 @@ def test_update_displays_pairs(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         payload = bot.update("cli", top_n=5)
     assert payload["green"] == "BTC"
-    assert "BTC" in caplog.text and "ETH" in caplog.text and "XRP" in caplog.text
+    assert "Listing ok" in caplog.text
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -136,13 +136,13 @@ def test_format_text_pair_list_and_start():
     text = notifier._format_text(
         "pair_list", {"green": "AAA", "orange": "BBB", "red": "CCC"}
     )
-    assert text == "Listing :\n🟢 AAA\n🟠 BBB\n🔴 CCC"
+    assert text == "Listing ok"
 
 
 def test_format_pair_list_helper():
     payload = {"green": "AAA", "orange": "BBB", "red": "CCC"}
     text = notifier._format_pair_list(payload)
-    assert text == "Listing :\n🟢 AAA\n🟠 BBB\n🔴 CCC"
+    assert text == "Listing ok"
 
 
 def test_format_position_event_helper():


### PR DESCRIPTION
## Summary
- simplify pair list notifications to only show `Listing ok`
- update tests for new listing output
- adjust README to describe simplified listing message

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7830f437c832797cc8308763d86eb