### PR TITLE
Handle update failures without stopping bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -198,8 +198,21 @@ def send_selected_pairs(client: Any, top_n: int = 40) -> Dict[str, str]:
 
 
 def update(client: Any, top_n: int = 40) -> Dict[str, str]:
-    """Send a fresh list of pairs to reflect current market conditions."""
-    payload = send_selected_pairs(client, top_n=top_n)
+    """Send a fresh list of pairs to reflect current market conditions.
+
+    ``send_selected_pairs`` performs network requests and may raise an
+    exception when the exchange is unreachable.  Previously such an error
+    would bubble up to the caller and could stop the bot.  The function now
+    guards the call so that a failure simply results in an empty payload while
+    logging the error, allowing the rest of the bot to continue running.
+    """
+
+    try:
+        payload = send_selected_pairs(client, top_n=top_n)
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.error("Erreur sélection paires: %s", exc)
+        payload = {}
+
     text = _format_text("pair_list", payload)
     logging.info(text)
     return payload

--- a/tests/test_bot_update.py
+++ b/tests/test_bot_update.py
@@ -13,3 +13,20 @@ def test_update_displays_pairs(monkeypatch, caplog):
     assert payload["green"] == "BTC"
     assert "Listing ok" in caplog.text
 
+
+def test_update_survives_errors(monkeypatch, caplog):
+    """``update`` should never raise even if pair selection fails."""
+
+    def boom(client, top_n=40):  # pragma: no cover - simulated failure
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(bot, "send_selected_pairs", boom)
+    with caplog.at_level(logging.INFO):
+        payload = bot.update("cli", top_n=5)
+
+    # The function returns an empty payload and logs the error, but still logs
+    # the "Listing ok" acknowledgement so callers can proceed.
+    assert payload == {}
+    assert "network down" in caplog.text
+    assert "Listing ok" in caplog.text
+


### PR DESCRIPTION
## Summary
- prevent `update` from crashing when fetching pair listings fails
- cover error-handling scenario with new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a785f927648327863ba894465f4224