### PR TITLE
Handle zero available balance correctly

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,19 @@ def test_extract_available_balance_fallback():
     assert extract_available_balance(assets) == 150.5
 
 
-def test_extract_available_balance_equity():
+def test_extract_available_balance_equity_only():
+    assets = {
+        "data": [
+            {
+                "currency": "USDT",
+                "equity": "42",
+            }
+        ]
+    }
+    assert extract_available_balance(assets) == 42.0
+
+
+def test_extract_available_balance_zero_available_returns_zero():
     assets = {
         "data": [
             {
@@ -61,4 +73,4 @@ def test_extract_available_balance_equity():
             }
         ]
     }
-    assert extract_available_balance(assets) == 42.0
+    assert extract_available_balance(assets) == 0.0


### PR DESCRIPTION
## Summary
- avoid sizing trades against equity when available balance is zero
- cover balance extraction edge cases in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78a4ae774832798cf8fce6f366394