### PR TITLE
Fix timeout exit time units

### DIFF
--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -266,13 +266,30 @@ def timeout_exit(
     progress_min: float = 15.0,
     timeout_min: float = 30.0,
 ) -> bool:
-    """Return ``True`` when a position should be closed for lack of progress."""
+    """Return ``True`` when a position should be closed for lack of progress.
+
+    Parameters
+    ----------
+    entry_time, now:
+        Timestamps in **seconds**.  ``progress_min`` and ``timeout_min`` are
+        expressed in minutes and converted to seconds inside the function so
+        callers can provide human-friendly minute values.
+    """
+
+    # Convert the minute based thresholds to seconds for comparison with the
+    # epoch based ``entry_time``/``now`` values.
+    progress_sec = progress_min * 60.0
+    timeout_sec = timeout_min * 60.0
 
     elapsed = now - entry_time
-    if elapsed >= timeout_min:
+    if elapsed >= timeout_sec:
         return True
-    if elapsed >= progress_min:
-        progress = (current_price - entry_price) if side.lower() == "long" else (entry_price - current_price)
+    if elapsed >= progress_sec:
+        progress = (
+            current_price - entry_price
+            if side.lower() == "long"
+            else entry_price - current_price
+        )
         return progress <= 0
     return False
 

--- a/tests/test_strategy_v2.py
+++ b/tests/test_strategy_v2.py
@@ -85,7 +85,10 @@ def test_trailing_and_timeout():
     assert should_scale_in(100, 105, 100, 10, "long") is True
     assert should_scale_in(100, 95, 100, 10, "short") is True
     # timeout
-    assert timeout_exit(0, 20, 100, 99, "long", progress_min=15, timeout_min=30)
+    # before the progress window no exit should be triggered
+    assert not timeout_exit(0, 10 * 60, 100, 99, "long", progress_min=15, timeout_min=30)
+    # after ``progress_min`` minutes without favourable movement we close
+    assert timeout_exit(0, 20 * 60, 100, 99, "long", progress_min=15, timeout_min=30)
 
 
 def test_generate_signal_macd_filter(monkeypatch):


### PR DESCRIPTION
## Summary
- interpret timeout_exit thresholds in minutes by converting to seconds
- adjust strategy test to reflect minute-based timeout behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78dda92c0832781a0b189b8a19fc9