### PR TITLE
Track open positions during trading

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -336,6 +336,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     take_profit = None
     session_pnl = 0.0
     last_entry_price = None
+    open_positions: set[str] = set()
 
     def close_position(side: int, price: float, vol: int) -> bool:
         nonlocal current_pos, entry_price, entry_time, session_pnl, equity_usdt, stop_long, stop_short, take_profit
@@ -413,6 +414,15 @@ def main(argv: Optional[List[str]] = None) -> None:
         stop_long = stop_short = None
         take_profit = None
         last_entry_price = None
+        if symbol in open_positions:
+            open_positions.remove(symbol)
+            log_event("open_positions", {"positions": list(open_positions)})
+        else:
+            logging.warning("Fermeture d'une position non suivie: %s", symbol)
+            log_event(
+                "open_positions",
+                {"positions": list(open_positions), "missing": symbol},
+            )
         time.sleep(0.3)
         return kill
 
@@ -783,6 +793,8 @@ def main(argv: Optional[List[str]] = None) -> None:
                 stop_short = None
                 take_profit = tp_long
                 last_entry_price = entry_price
+                open_positions.add(symbol)
+                log_event("open_positions", {"positions": list(open_positions)})
 
             elif x == -1 and current_pos >= 0:
                 if current_pos > 0 and entry_price is not None:
@@ -874,6 +886,8 @@ def main(argv: Optional[List[str]] = None) -> None:
                 stop_long = None
                 take_profit = tp_short
                 last_entry_price = entry_price
+                open_positions.add(symbol)
+                log_event("open_positions", {"positions": list(open_positions)})
 
             time.sleep(cfg["LOOP_SLEEP_SECS"])
 


### PR DESCRIPTION
## Summary
- Track currently open symbols during trading sessions
- Log and verify open position list when opening and closing trades
- Warn when attempting to close untracked positions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a792c39b50832788b14b3b16491095