### PR TITLE
Use actual position volume for Bitget closing orders

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -330,6 +330,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     prev_fast = prev_slow = None
     current_pos = 0
+    current_vol = 0
     entry_price = None
     entry_time = None
     stop_long = stop_short = None
@@ -354,7 +355,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             logging.warning("Impossible de récupérer les positions Bitget: %s", exc)
 
     def close_position(side: int, price: float, vol: int) -> bool:
-        nonlocal current_pos, entry_price, entry_time, session_pnl, equity_usdt, stop_long, stop_short, take_profit
+        nonlocal current_pos, current_vol, entry_price, entry_time, session_pnl, equity_usdt, stop_long, stop_short, take_profit
         pnl = round(calc_pnl_pct(entry_price, price, side, fee_rate), 2)
         payload = {
             "side": "long" if side > 0 else "short",
@@ -424,6 +425,7 @@ def main(argv: Optional[List[str]] = None) -> None:
             }
         )
         current_pos = 0
+        current_vol = 0
         entry_price = None
         entry_time = None
         stop_long = stop_short = None
@@ -577,18 +579,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 price_str = tdata.get("lastPr") or tdata.get("lastPrice")
                 price = float(price_str)
 
-            vol_close = compute_position_size(
-                contract_detail,
-                equity_usdt,
-                price,
-                risk_mgr.risk_pct,
-                cfg["LEVERAGE"],
-                symbol,
-            )
-            if vol_close <= 0:
-                logging.info("vol calculé = 0; on attend.")
-                time.sleep(cfg["LOOP_SLEEP_SECS"])
-                continue
+            vol_close = current_vol
             sl_long = price * (1.0 - cfg["STOP_LOSS_PCT"])
             tp_long = price * (1.0 + cfg["TAKE_PROFIT_PCT"])
             sl_short = price * (1.0 + cfg["STOP_LOSS_PCT"])
@@ -671,6 +662,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                         )
                         log_event("scale_in_long", resp)
                         last_entry_price = price
+                        current_vol += vol_add
             elif (
                 current_pos < 0
                 and entry_price is not None
@@ -706,6 +698,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                         )
                         log_event("scale_in_short", resp)
                         last_entry_price = price
+                        current_vol += vol_add
 
             log_event(
                 "signal",
@@ -803,6 +796,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 log_event("position_opened", open_payload)
                 notify("position_opened", open_payload)
                 current_pos = +1
+                current_vol = vol_open
                 entry_price = price
                 entry_time = now_ts
                 stop_long = sl_long
@@ -897,6 +891,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 log_event("position_opened", open_payload)
                 notify("position_opened", open_payload)
                 current_pos = -1
+                current_vol = vol_open
                 entry_price = price
                 entry_time = now_ts
                 stop_short = sl_short


### PR DESCRIPTION
## Summary
- Track currently open contract volume and reuse it when exiting positions
- Update scaling logic to accumulate volume so closing orders match exposure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a802a524dc8327898df5f3455afda6