### PR TITLE
feat: add dynamic risk scoring and caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+- Trigger trade entries via `strategy.generate_signal` with weighted scoring and
+  signal levels.
+- Dynamic risk management adapting `risk_pct` and leverage based on signal and
+  user risk level.
+- Notional and margin caps with available balance check to avoid Bitget error
+  `40762`.
+- Risk notifications with green/yellow/red indicators for terminal and
+  Telegram.

--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -80,6 +80,15 @@ def _format_position_event(event: str, payload: Dict[str, Any]) -> str:
         hold = payload.get("hold") or payload.get("expected_duration")
         if hold is not None:
             lines.append(f"Durée prévue: {hold}")
+        rc = payload.get("risk_color")
+        if rc:
+            lvl = payload.get("sig_level")
+            score = payload.get("score")
+            lines.append(f"Risque: {rc} L{lvl} score {score}")
+        rp = payload.get("risk_pct_eff")
+        lev_eff = payload.get("leverage_eff")
+        if rp is not None and lev_eff is not None:
+            lines.append(f"Risk%: {rp:.4f} Levier eff.: x{lev_eff}")
     else:  # position_closed
         pnl_usd = payload.get("pnl_usd")
         if pnl_usd is not None and pnl_pct is not None:

--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -66,6 +66,7 @@ def compute_position_size(
     risk_pct: float,
     leverage: int,
     symbol: Optional[str] = None,
+    available_usdt: Optional[float] = None,
 ) -> int:
     """Return contract volume to trade for the given risk parameters.
 
@@ -118,6 +119,17 @@ def compute_position_size(
         notional = vol * denom
         if notional < min_usdt:
             return 0
+
+    if available_usdt is not None:
+        cap = available_usdt / (1 / float(leverage) + fee_rate)
+        cap_vol = int(math.floor(cap / denom / vol_unit) * vol_unit)
+        if cap_vol < min_vol:
+            return 0
+        if vol > cap_vol:
+            vol = cap_vol
+            notional = vol * denom
+            if notional < min_usdt:
+                return 0
 
     return vol
 

--- a/tests/test_bot_place_order_caps.py
+++ b/tests/test_bot_place_order_caps.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules['requests'] = types.ModuleType('requests')
+
+from bot import attempt_entry, Signal
+
+
+class DummyClient:
+    def __init__(self):
+        self.last_order = None
+
+    def place_order(self, *args, **kwargs):  # pragma: no cover - simple store
+        self.last_order = (args, kwargs)
+        return {"code": "00000"}
+
+
+class DummyRisk:
+    def __init__(self, pct):
+        self.risk_pct = pct
+
+
+def _detail():
+    return {
+        "data": [
+            {
+                "symbol": "BTC_USDT",
+                "contractSize": 0.001,
+                "volUnit": 1,
+                "minVol": 1,
+                "minTradeUSDT": 5,
+            }
+        ]
+    }
+
+
+def test_attempt_entry_respects_caps(monkeypatch):
+    captured = {}
+
+    def fake_notify(event, payload):
+        captured[event] = payload
+
+    monkeypatch.setattr("bot.notify", fake_notify)
+    client = DummyClient()
+    sig = Signal("BTC_USDT", "long", 10000, 9900, 10100, 10200, 1, score=80)
+    rm = DummyRisk(0.02)
+    available = 1000
+    params = attempt_entry(
+        client,
+        _detail(),
+        sig,
+        equity_usdt=available,
+        available_usdt=available,
+        cfg={"LEVERAGE": 10},
+        risk_mgr=rm,
+        user_risk_level=1,
+    )
+    assert client.last_order is not None
+    assert "risk_color" in captured["position_opened"]
+
+
+def test_attempt_entry_insufficient_margin(monkeypatch):
+    captured = {}
+
+    def fake_notify(event, payload):
+        captured[event] = payload
+
+    monkeypatch.setattr("bot.notify", fake_notify)
+    client = DummyClient()
+    sig = Signal("BTC_USDT", "long", 10000, 9900, 10100, 10200, 1, score=80)
+    rm = DummyRisk(0.02)
+    available = 0.5
+    params = attempt_entry(
+        client,
+        _detail(),
+        sig,
+        equity_usdt=available,
+        available_usdt=available,
+        cfg={"LEVERAGE": 10},
+        risk_mgr=rm,
+        user_risk_level=1,
+    )
+    assert client.last_order is None
+    assert params["vol"] == 0
+    assert captured["order_attempt"]["risk_color"]

--- a/tests/test_compute_position_size_cap.py
+++ b/tests/test_compute_position_size_cap.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules['requests'] = types.ModuleType('requests')
+
+from bot import compute_position_size, CONFIG
+
+
+def _detail(vol_unit=1, min_vol=1, min_trade=5):
+    return {
+        "data": [
+            {
+                "symbol": "BTC_USDT",
+                "contractSize": 0.001,
+                "volUnit": vol_unit,
+                "minVol": min_vol,
+                "minTradeUSDT": min_trade,
+            }
+        ]
+    }
+
+
+def test_volume_zero_when_available_low():
+    detail = _detail()
+    vol = compute_position_size(
+        detail,
+        equity_usdt=1000,
+        price=10000,
+        risk_pct=0.01,
+        leverage=10,
+        symbol="BTC_USDT",
+        available_usdt=0.5,
+    )
+    assert vol == 0
+
+
+def test_margin_close_to_available():
+    detail = _detail()
+    CONFIG["FEE_RATE"] = 0.001
+    available = 1.05
+    vol = compute_position_size(
+        detail,
+        equity_usdt=1000,
+        price=10000,
+        risk_pct=1,
+        leverage=10,
+        symbol="BTC_USDT",
+        available_usdt=available,
+    )
+    assert vol == 1
+    notional = 10000 * 0.001 * vol
+    fee = max(CONFIG.get("FEE_RATE", 0.0), 0.001) * notional
+    required = (notional / 10 + fee) * 1.03
+    assert required == pytest.approx(available, rel=0.05)
+
+
+def test_respects_units_and_minimums():
+    detail = _detail(vol_unit=2, min_vol=2, min_trade=5)
+    vol = compute_position_size(
+        detail,
+        equity_usdt=1000,
+        price=1000,
+        risk_pct=1,
+        leverage=5,
+        symbol="BTC_USDT",
+        available_usdt=1000,
+    )
+    assert vol % 2 == 0 and vol >= 2

--- a/tests/test_signal_risk.py
+++ b/tests/test_signal_risk.py
@@ -1,0 +1,63 @@
+import types
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules['requests'] = types.ModuleType('requests')
+
+from bot import (
+    map_score_to_sig_level,
+    compute_risk_params,
+    prepare_order,
+    Signal,
+    CONFIG,
+)
+
+
+class DummyRisk:
+    def __init__(self, pct: float) -> None:
+        self.risk_pct = pct
+
+
+def _contract_detail():
+    return {
+        "data": [
+            {
+                "symbol": "BTC_USDT",
+                "contractSize": 0.001,
+                "volUnit": 1,
+                "minVol": 1,
+                "minTradeUSDT": 5,
+            }
+        ]
+    }
+
+
+def test_score_to_level_mapping():
+    assert map_score_to_sig_level(10) == 1
+    assert map_score_to_sig_level(35) == 2
+    assert map_score_to_sig_level(69.9) == 2
+    assert map_score_to_sig_level(70) == 3
+
+
+def test_risk_tables():
+    rp, lev, cap = compute_risk_params(2, 3, 0.01, 20)
+    assert rp == 0.01 * 1.25
+    assert lev == int(20 * 0.75)
+    assert cap == 0.55
+
+
+def test_notional_cap():
+    rm = DummyRisk(0.05)
+    sig = Signal("BTC_USDT", "long", 10000, 9900, 10100, 10200, 1, score=80)
+    available = 1000
+    params = prepare_order(
+        sig,
+        _contract_detail(),
+        equity_usdt=available,
+        available_usdt=available,
+        base_leverage=10,
+        risk_mgr=rm,
+        user_risk_level=2,
+    )
+    assert params["notional"] <= params["cap_ratio"] * available + 1e-6


### PR DESCRIPTION
## Summary
- score trading signals and expose quality, reasons
- adapt risk & leverage with signal levels and cap orders by balance
- notify risk colour and margin details to prevent Bitget 40762

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80ebf625083279bc1f47500be321b