### PR TITLE
Implement margin caps and contract-size aware risk notifications

### DIFF
--- a/scalp/notifier.py
+++ b/scalp/notifier.py
@@ -89,6 +89,14 @@ def _format_position_event(event: str, payload: Dict[str, Any]) -> str:
         lev_eff = payload.get("leverage_eff")
         if rp is not None and lev_eff is not None:
             lines.append(f"Risk%: {rp:.4f} Levier eff.: x{lev_eff}")
+        req = payload.get("required_margin")
+        avail = payload.get("available")
+        if req is not None and avail is not None:
+            lines.append(f"Marge: {req:.2f}/{avail}")
+        vb = payload.get("vol_before")
+        vf = payload.get("vol")
+        if vb is not None and vf is not None and vb != vf:
+            lines.append(f"Vol: {vb}->{vf}")
     else:  # position_closed
         pnl_usd = payload.get("pnl_usd")
         if pnl_usd is not None and pnl_pct is not None:

--- a/tests/test_notional_and_pnl_units.py
+++ b/tests/test_notional_and_pnl_units.py
@@ -1,0 +1,18 @@
+import os, sys, types, pytest
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules['requests'] = types.ModuleType('requests')
+
+from bot import _estimate_margin
+from scalp.trade_utils import compute_pnl_usdt
+
+
+def _detail():
+    return {"data": [{"symbol": "BTC_USDT", "contractSize": 0.001}]}
+
+
+def test_notional_and_pnl_units():
+    detail = _detail()
+    notional, margin = _estimate_margin(detail, price=10000, vol=2, leverage=10)
+    assert notional == pytest.approx(10000 * 0.001 * 2)
+    pnl = compute_pnl_usdt(detail, 10000, 10100, 2, 1, symbol="BTC_USDT")
+    assert pnl == pytest.approx((10100 - 10000) * 0.001 * 2)

--- a/tests/test_signal_risk.py
+++ b/tests/test_signal_risk.py
@@ -45,6 +45,10 @@ def test_risk_tables():
     assert rp == 0.01 * 1.25
     assert lev == int(20 * 0.75)
     assert cap == 0.55
+    rp2, lev2, cap2 = compute_risk_params(3, 1, 0.01, 20)
+    assert rp2 == 0.01 * 1.0
+    assert lev2 == int(20 * 0.5)
+    assert cap2 == 0.35
 
 
 def test_notional_cap():


### PR DESCRIPTION
## Summary
- normalize contract sizing and add PnL helper using `contractSize`
- compute risk-aware leverage and cap order sizes by available margin
- enrich order notifications with risk colour, score, volume adjustments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a816a32108832786b8bc62553f9a67