### PR TITLE
Refine margin and PnL notifications for Bitget scalping bot

### DIFF
--- a/scalp/telegram_bot.py
+++ b/scalp/telegram_bot.py
@@ -227,10 +227,14 @@ class TelegramBot:
                 base = self._base_symbol(symbol)
                 side = p.get("side")
                 vol = p.get("vol")
-                pnl = p.get("pnl_usd")
+                pnl = p.get("pnl_usdt")
+                if pnl is None:
+                    pnl = p.get("pnl_usd")
                 if pnl is None:
                     pnl = p.get("pnl")
-                pnl_pct = p.get("pnl_pct")
+                pnl_pct = p.get("pnl_pct_on_margin")
+                if pnl_pct is None:
+                    pnl_pct = p.get("pnl_pct")
                 line = f"{base} {side} {vol}"
                 if pnl is not None and pnl_pct is not None:
                     line += f"\nPnL: {pnl:.2f} USDT ({pnl_pct:.2f}%)"

--- a/scalp/trade_utils.py
+++ b/scalp/trade_utils.py
@@ -8,13 +8,13 @@ from typing import Any, Dict, List, Optional, Tuple
 from scalp.bot_config import CONFIG
 
 
-def extract_contract_size(contract_detail: Dict[str, Any], symbol: Optional[str] = None) -> float:
-    """Return the contract size for ``symbol`` from Bitget contract detail.
+def get_contract_size(contract_detail: Dict[str, Any], symbol: Optional[str] = None) -> float:
+    """Return the contract size for ``symbol``.
 
-    Bitget's API sometimes exposes the contract unit as ``contractSize`` or
-    ``sizeMultiplier`` depending on the endpoint or product type.  This helper
-    normalises the two so the rest of the code base has a single source of
-    truth for volume to notional conversions.
+    Bitget may expose the contract unit as ``contractSize`` or
+    ``sizeMultiplier`` depending on the endpoint.  This helper normalises the
+    two so the rest of the code base has a single source of truth for
+    conversions between contract volume and notional value.
     """
 
     symbol = symbol or CONFIG.get("SYMBOL")
@@ -28,6 +28,35 @@ def extract_contract_size(contract_detail: Dict[str, Any], symbol: Optional[str]
         return float(size)
     except (TypeError, ValueError):
         return 1.0
+
+
+# Backwards compatibility: old name used internally/tests
+extract_contract_size = get_contract_size
+
+
+def notional(price: float, vol: float, contract_size: float) -> float:
+    """Return the notional value in USDT for ``vol`` contracts."""
+
+    return float(price) * float(vol) * float(contract_size)
+
+
+def required_margin(
+    notion: float,
+    lev: float,
+    fee_rate: float,
+    buffer: float = 0.03,
+) -> float:
+    """Return estimated required margin including fees and buffer.
+
+    The margin is the sum of the collateral required by the leverage and the
+    estimated taker fees for both sides of the trade.  ``buffer`` adds an extra
+    safety margin to account for slight price movements between order placement
+    and execution.
+    """
+
+    lev = max(float(lev), 1.0)
+    fee = float(fee_rate)
+    return (notion / lev + fee * notion) * (1.0 + buffer)
 
 
 def extract_available_balance(assets: Dict[str, Any], currency: str = "USDT") -> float:
@@ -109,7 +138,7 @@ def compute_position_size(
     if contract is None:
         raise ValueError("Contract detail introuvable pour le symbole")
 
-    contract_size = extract_contract_size(contract_detail, symbol)
+    contract_size = get_contract_size(contract_detail, symbol)
     vol_unit = int(contract.get("volUnit", 1))
     min_vol = int(contract.get("minVol", 1))
     min_usdt = float(contract.get("minTradeUSDT", 5))
@@ -167,9 +196,35 @@ def compute_pnl_usdt(
 ) -> float:
     """Return PnL in USDT using contract size for ``vol`` contracts."""
 
-    size = extract_contract_size(contract_detail, symbol)
+    size = get_contract_size(contract_detail, symbol)
     diff = (exit_price - entry_price) * (1 if side > 0 else -1)
     return diff * size * vol
+
+
+def compute_pnl_with_fees(
+    contract_detail: Dict[str, Any],
+    entry_price: float,
+    exit_price: float,
+    vol: float,
+    side: int,
+    leverage: float,
+    fee_rate: float,
+    symbol: Optional[str] = None,
+) -> Tuple[float, float]:
+    """Return net PnL in USDT and percentage on margin.
+
+    ``side`` should be ``1`` for long positions and ``-1`` for shorts.
+    """
+
+    cs = get_contract_size(contract_detail, symbol)
+    n_entry = notional(entry_price, vol, cs)
+    n_exit = notional(exit_price, vol, cs)
+    gross = (exit_price - entry_price) * vol * cs * (1 if side > 0 else -1)
+    fees = fee_rate * (n_entry + n_exit)
+    pnl = gross - fees
+    margin = n_entry / max(float(leverage), 1.0)
+    pct = 0.0 if margin == 0 else pnl / margin * 100.0
+    return pnl, pct
 
 def effective_leverage(
     entry_price: float,

--- a/tests/test_bot_place_order_caps.py
+++ b/tests/test_bot_place_order_caps.py
@@ -58,7 +58,10 @@ def test_attempt_entry_respects_caps(monkeypatch):
         user_risk_level=1,
     )
     assert client.last_order is not None
-    assert "risk_color" in captured["position_opened"]
+    opened = captured["position_opened"]
+    assert "risk_color" in opened
+    assert "required_margin_usdt" in opened
+    assert "notional_usdt" in opened
 
 
 def test_attempt_entry_insufficient_margin(monkeypatch):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -92,43 +92,55 @@ def test_notify_skips_telegram_for_pair_list(monkeypatch):
 
 def test_format_text_open_position():
     payload = {
-        "side": "long",
         "symbol": "BTCUSDT",
-        "vol": 1,
-        "leverage": 10,
-        "amount_usdt": 100,
-        "tp_usd": 5,
-        "sl_usd": 2,
-        "hold": "2h",
+        "side": "short",
+        "price": 18350,
+        "vol": 37,
+        "contract_size": 1,
+        "notional_usdt": 120.5,
+        "leverage": 5,
+        "required_margin_usdt": 25.3,
+        "available_usdt": 134,
+        "risk_level_user": 3,
+        "signal_level": 2,
+        "risk_color": "🟡",
+        "risk_pct_eff": 0.01,
+        "fee_rate": 0.001,
     }
     text = notifier._format_text("position_opened", payload)
     lines = text.splitlines()
 
-    assert lines[0] == "Ouvre long 📈 BTC"
-    assert lines[1] == "Montant: 100 USDT"
-    assert lines[2] == "Levier: x10"
-    assert "TP: +5 USDT" in lines
-    assert "SL: -2 USDT" in lines
-    assert any("Durée prévue: 2h" in line for line in lines)
+    assert lines[0] == "🟡 Ouvre short BTC"
+    assert lines[1] == "Notional: 120.5 USDT   Levier: x5"
+    assert lines[2] == "Marge estimée: 25.3 USDT (dispo: 134 USDT)"
+    assert lines[3] == "Risque: lvl 2/3 (risk_pct=1.0000%)"
+    assert lines[4] == "Prix: 18350   Vol: 37 (cs=1)"
 
 
 def test_format_text_closed_position():
     payload = {
+        "symbol": "BTCUSDT",
         "side": "short",
-        "symbol": "ETHUSDT",
-        "vol": 2,
+        "entry_price": 18350,
+        "exit_price": 18328,
+        "vol": 37,
+        "contract_size": 1,
+        "notional_entry_usdt": 120.5,
+        "notional_exit_usdt": 120.3,
+        "fees_usdt": 0.03,
+        "pnl_usdt": 0.84,
+        "pnl_pct_on_margin": 3.25,
         "leverage": 5,
-        "pnl_usd": 12,
-        "pnl_pct": 3,
-        "duration": "1h",
+        "risk_color": "🟡",
+        "fee_rate": 0.001,
     }
     text = notifier._format_text("position_closed", payload)
     lines = text.splitlines()
-    assert lines[0] == "Ferme short 📉 ETH ✅🎯"
-    assert lines[1] == "Position: 2"
-    assert lines[2] == "Levier: x5"
-    assert any("PnL: 12 USDT (3.00%)" in line for line in lines)
-    assert any("Durée: 1h" in line for line in lines)
+    assert lines[0] == "Ferme short BTC 🟡"
+    assert lines[1] == "PnL net: +0.84 USDT (frais: 0.03)"
+    assert lines[2] == "% sur marge: 3.25%"
+    assert lines[3] == "Entrée: 18350  Sortie: 18328"
+    assert lines[4] == "Vol: 37  Notional: in 120.5 → out 120.3 USDT"
 
 
 def test_format_text_pair_list_and_start():
@@ -147,15 +159,22 @@ def test_format_pair_list_helper():
 
 def test_format_position_event_helper():
     payload = {
-        "side": "long",
         "symbol": "BTCUSDT",
-        "vol": 1,
-        "leverage": 10,
-        "amount_usdt": 100,
-        "tp_pct": 5,
-        "sl_pct": 2,
+        "side": "short",
+        "price": 18350,
+        "vol": 37,
+        "contract_size": 1,
+        "notional_usdt": 120.5,
+        "leverage": 5,
+        "required_margin_usdt": 25.3,
+        "available_usdt": 134,
+        "risk_level_user": 3,
+        "signal_level": 2,
+        "risk_color": "🟡",
+        "risk_pct_eff": 0.01,
+        "fee_rate": 0.001,
     }
     text = notifier._format_position_event("position_opened", payload)
-    assert text.splitlines()[0] == "Ouvre long 📈 BTC"
+    assert text.splitlines()[0] == "🟡 Ouvre short BTC"
 
 

--- a/tests/test_notional_and_pnl_units.py
+++ b/tests/test_notional_and_pnl_units.py
@@ -2,8 +2,13 @@ import os, sys, types, pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 sys.modules['requests'] = types.ModuleType('requests')
 
-from bot import _estimate_margin
-from scalp.trade_utils import compute_pnl_usdt
+from scalp.trade_utils import (
+    get_contract_size,
+    notional,
+    required_margin,
+    compute_pnl_usdt,
+    compute_pnl_with_fees,
+)
 
 
 def _detail():
@@ -12,7 +17,19 @@ def _detail():
 
 def test_notional_and_pnl_units():
     detail = _detail()
-    notional, margin = _estimate_margin(detail, price=10000, vol=2, leverage=10)
-    assert notional == pytest.approx(10000 * 0.001 * 2)
+    cs = get_contract_size(detail, "BTC_USDT")
+    N = notional(10000, 2, cs)
+    assert N == pytest.approx(10000 * 0.001 * 2)
+    margin = required_margin(N, 10, 0.001, buffer=0.0)
+    assert margin == pytest.approx(N / 10 + 0.001 * N)
     pnl = compute_pnl_usdt(detail, 10000, 10100, 2, 1, symbol="BTC_USDT")
     assert pnl == pytest.approx((10100 - 10000) * 0.001 * 2)
+    pnl_net, pct = compute_pnl_with_fees(
+        detail, 10000, 10100, 2, 1, 10, 0.001, symbol="BTC_USDT"
+    )
+    gross = (10100 - 10000) * cs * 2
+    fees = 0.001 * (notional(10000, 2, cs) + notional(10100, 2, cs))
+    expected = gross - fees
+    expected_pct = expected / (N / 10) * 100
+    assert pnl_net == pytest.approx(expected)
+    assert pct == pytest.approx(expected_pct)


### PR DESCRIPTION
## Summary
- standardize contract sizing helpers and margin/pnl calculations
- publish unified position_opened/position_closed payloads with margin, risk, and net PnL
- align Telegram/terminal formatting and tests for new notifications

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a81cdadf948327ae36e4cd1e2f111f