### PR TITLE
fix: enforce notional helpers and margin checks

### DIFF
--- a/tests/test_min_qty_rules.py
+++ b/tests/test_min_qty_rules.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules['requests'] = types.ModuleType('requests')
+
+from bot import _apply_contract_checks
+
+
+def _detail():
+    return {
+        "data": [
+            {
+                "symbol": "BTC_USDT",
+                "contractSize": 1,
+                "volUnit": 5,
+                "minVol": 10,
+                "minTradeUSDT": 5,
+            }
+        ]
+    }
+
+
+def test_min_qty_floor_and_validation():
+    detail = _detail()
+    vol, N, req = _apply_contract_checks(1, 13, 10, 100, detail, "BTC_USDT")
+    assert vol == 10
+    vol2, N2, req2 = _apply_contract_checks(1, 7, 10, 100, detail, "BTC_USDT")
+    assert vol2 == 0

--- a/tests/test_notional_and_pnl_units.py
+++ b/tests/test_notional_and_pnl_units.py
@@ -4,8 +4,8 @@ sys.modules['requests'] = types.ModuleType('requests')
 
 from scalp.trade_utils import (
     get_contract_size,
-    notional,
-    required_margin,
+    notional as calc_notional,
+    required_margin as calc_required_margin,
     compute_pnl_usdt,
     compute_pnl_with_fees,
 )
@@ -18,9 +18,9 @@ def _detail():
 def test_notional_and_pnl_units():
     detail = _detail()
     cs = get_contract_size(detail, "BTC_USDT")
-    N = notional(10000, 2, cs)
+    N = calc_notional(10000, 2, cs)
     assert N == pytest.approx(10000 * 0.001 * 2)
-    margin = required_margin(N, 10, 0.001, buffer=0.0)
+    margin = calc_required_margin(N, 10, 0.001, buffer=0.0)
     assert margin == pytest.approx(N / 10 + 0.001 * N)
     pnl = compute_pnl_usdt(detail, 10000, 10100, 2, 1, symbol="BTC_USDT")
     assert pnl == pytest.approx((10100 - 10000) * 0.001 * 2)
@@ -28,7 +28,7 @@ def test_notional_and_pnl_units():
         detail, 10000, 10100, 2, 1, 10, 0.001, symbol="BTC_USDT"
     )
     gross = (10100 - 10000) * cs * 2
-    fees = 0.001 * (notional(10000, 2, cs) + notional(10100, 2, cs))
+    fees = 0.001 * (calc_notional(10000, 2, cs) + calc_notional(10100, 2, cs))
     expected = gross - fees
     expected_pct = expected / (N / 10) * 100
     assert pnl_net == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- avoid function/variable name shadowing by aliasing notional and margin helpers
- validate min quantity and margin with unified helper before placing orders
- add regression tests for sizing caps and contract rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a82840af648327a2563a48ed9dd029