### PR TITLE
Pin pydantic for Python <3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 python-dotenv
-pydantic>=2
+pydantic==1.10.15 ; python_version < "3.11"


### PR DESCRIPTION
## Summary
- pin pydantic dependency to 1.10.15 for Python versions below 3.11

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a8671ad58883279db12326cc28e03b