### PR TITLE
Add comments clarifying dependency choices

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 requests
 python-dotenv
 pydantic==1.10.15 ; python_version < "3.11"
+
+# pydantic v1 déjà pin si environnement ancien
+# rien à ajouter ici pour market_data (pas de nouvelle dépendance)


### PR DESCRIPTION
## Summary
- clarify why pydantic v1 is pinned for old environments
- document that market_data adds no extra dependencies

## Testing
- `pytest -q` *(fails: cannot import name 'attempt_entry' from 'bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a86b8d4cb48327b140ec441c214bad