### PR TITLE
Add position management and telegram flat commands

### DIFF
--- a/live/orchestrator.py
+++ b/live/orchestrator.py
@@ -32,15 +32,13 @@ class Orchestrator:
         self.config = config
         self.symbols = list(symbols)
         self.ctx: Dict[str, SymbolContext] = {s: SymbolContext(s, []) for s in self.symbols}
-        self.pos: Dict[str, PositionState] = {}
-        # initialiser état par symbole
-        for s in self.symbols:
-            self.pos[s] = PositionState(symbol=s, side=PositionSide.LONG)  # side réel fixé à l’entrée
         self._running = False
         self._tasks: List[asyncio.Task] = []
         self._heartbeat_ts = 0.0
         # util de normalisation utilisé partout
         self._row_keys = ("ts", "open", "high", "low", "close", "volume")
+        # état positions par symbole
+        self.pos: Dict[str, PositionState] = {s: PositionState(s, PositionSide.LONG) for s in self.symbols}
         self._paused = False
         self._tg = TelegramAsync(
             token=getattr(config, "TELEGRAM_BOT_TOKEN", None),
@@ -187,17 +185,17 @@ class Orchestrator:
                     )
                     res = self.order_service.prepare_and_place(equity_usdt, req)
                     if res.accepted:
-                        ctx.position_open = True  # legacy (peut rester pour logs)
+                        ctx.position_open = True
                         ctx.last_signal_ts = time.time()
+                        # alimente FSM
                         side_enum = PositionSide.LONG if req.side == "long" else PositionSide.SHORT
-                        st = self.pos.get(symbol) or PositionState(symbol=symbol, side=side_enum)
+                        st = self.pos.get(symbol) or PositionState(symbol, side_enum)
                         st.side = side_enum
                         st.status = PositionStatus.PENDING_ENTRY
-                        st.entry_order_id = res.order_id
-                        st.req_qty = st.req_qty or 0.0
-                        st.req_qty = max(st.req_qty, 0.0) + (res.filled_qty or 0.0) if (res.filled_qty or 0.0) > 0 else st.req_qty or 0.0
-                        st.sl = float(getattr(req, "sl", 0)) or None
-                        st.tp = float(getattr(req, "tp", 0)) or None
+                        st.entry_order_id = res.order_id or st.entry_order_id
+                        st.req_qty = st.req_qty or (res.filled_qty or 0.0) or 0.0
+                        st.sl = req.sl
+                        st.tp = req.tp
                         self.pos[symbol] = st
                         print(f"[order] {symbol} accepted")
                         if self._tg.enabled():
@@ -216,69 +214,98 @@ class Orchestrator:
         while self._running:
             try:
                 for symbol, st in list(self.pos.items()):
-                    # 1) si PENDING_ENTRY -> consulter fills de l’order d’entrée
+                    # PENDING_ENTRY -> consommer fills
                     if st.status == PositionStatus.PENDING_ENTRY and st.entry_order_id:
-                        fills = self.exchange.get_fills(symbol, order_id=st.entry_order_id).get("data", [])
-                        for f in fills:
-                            fill = Fill(order_id=f["orderId"], trade_id=f["tradeId"], price=float(f["price"]), qty=float(f["qty"]), fee=float(f.get("fee",0)), ts=int(f.get("ts",0)))
+                        data = self.exchange.get_fills(symbol, order_id=st.entry_order_id)
+                        for f in (data.get("data") or []):
+                            fill = Fill(
+                                order_id=str(f.get("orderId") or f.get("ordId") or ""),
+                                trade_id=str(f.get("tradeId") or f.get("fillId") or f.get("execId") or ""),
+                                price=float(f.get("price", f.get("fillPx", 0))),
+                                qty=float(f.get("qty", f.get("fillSz", 0))),
+                                fee=float(f.get("fee", f.get("fillFee", 0))),
+                                ts=int(f.get("ts", f.get("time", 0))),
+                            )
                             st.apply_fill_entry(fill)
-                        # si toujours pas OPEN, vérifier statut ordre
-                        if st.status == PositionStatus.PENDING_ENTRY:
-                            orders = self.exchange.get_recent_orders(symbol).get("data", [])
-                            for o in orders:
-                                if o["orderId"] == st.entry_order_id:
-                                    st.last_sync_ts = int(time.time()*1000)
-                                    if o.get("status") in ("canceled","cancelled","rejected","expired"):
-                                        # ordre tombé -> retour à IDLE
-                                        st.status = PositionStatus.IDLE
-                                        st.entry_order_id = None
+                        # si toujours pas OPEN, vérifier positions visibles côté exchange
+                        if st.status != PositionStatus.OPEN:
+                            opens = self.exchange.get_open_positions(symbol).get("data", [])
+                            for p in opens:
+                                if p.get("symbol") == symbol and ((p.get("side") == "long") == (st.side == PositionSide.LONG)):
+                                    st.status = PositionStatus.OPEN
+                                    st.filled_qty = float(p.get("qty", st.filled_qty))
+                                    st.avg_entry_price = float(p.get("avgEntryPrice", st.avg_entry_price))
                                     break
-                    # 2) si OPEN -> vérifier si une position existe côté exchange
+                        self.pos[symbol] = st
+                    # OPEN -> vérifier si qty retombe à 0 (fermeture externe ou SL/TP)
                     elif st.status == PositionStatus.OPEN:
-                        # lire positions ouvertes
                         opens = self.exchange.get_open_positions(symbol).get("data", [])
-                        open_qty = 0.0
-                        avg = st.avg_entry_price
+                        qty_open = 0.0
                         for p in opens:
-                            if p["symbol"] == symbol and ((p["side"]=="long") == (st.side==PositionSide.LONG)):
-                                open_qty = float(p["qty"])
-                                avg = float(p.get("avgEntryPrice", avg))
+                            if p.get("symbol") == symbol and ((p.get("side") == "long") == (st.side == PositionSide.LONG)):
+                                qty_open = float(p.get("qty", 0.0))
                                 break
-                        st.avg_entry_price = avg or st.avg_entry_price
-                        if open_qty <= 1e-12:
-                            # position plus visible: soit fermée soit en fermeture
-                            # vérifier fills de l’order de sortie si on en a un
-                            if st.exit_order_id:
-                                fills = self.exchange.get_fills(symbol, order_id=st.exit_order_id).get("data", [])
-                                for f in fills:
-                                    fill = Fill(order_id=f["orderId"], trade_id=f["tradeId"], price=float(f["price"]), qty=float(f["qty"]), fee=float(f.get("fee",0)), ts=int(f.get("ts",0)))
+                        if qty_open <= 1e-12:
+                            # regarder fills récents (sortie)
+                            fills = self.exchange.get_fills(symbol).get("data", [])
+                            for f in fills:
+                                ts = int(f.get("ts", 0))
+                                if st.opened_ts and ts >= st.opened_ts:
+                                    fill = Fill(
+                                        order_id=str(f.get("orderId") or ""),
+                                        trade_id=str(f.get("tradeId") or f.get("fillId") or ""),
+                                        price=float(f.get("price", 0)),
+                                        qty=float(f.get("qty", 0)),
+                                        fee=float(f.get("fee", 0)),
+                                        ts=ts,
+                                    )
                                     st.apply_fill_exit(fill)
-                            # si toujours pas CLOSED, tenter une lecture des fills récents (sans order_id)
                             if st.status != PositionStatus.CLOSED:
-                                fills = self.exchange.get_fills(symbol).get("data", [])
-                                # garder uniquement ceux après opened_ts
-                                for f in fills:
-                                    if st.opened_ts and int(f.get("ts",0)) >= st.opened_ts:
-                                        # heuristique: sens inverse pour fermeture
-                                        qty = float(f["qty"])
-                                        side_exec = "buy" if qty < 0 else "sell"  # placeholder si l’API a le signe
-                                # Si aucune info, marquer CLOSED de façon conservatrice (à défaut)
                                 st.status = PositionStatus.CLOSED
                                 st.closed_ts = int(time.time()*1000)
-                        else:
-                            # mettre en cohérence la qty locale avec l’exchange
-                            st.filled_qty = open_qty
-                    # 3) si PENDING_EXIT -> consommer fills de l’order de sortie
+                            self.pos[symbol] = st
+                    # PENDING_EXIT -> consommer fills de sortie
                     elif st.status == PositionStatus.PENDING_EXIT and st.exit_order_id:
-                        fills = self.exchange.get_fills(symbol, order_id=st.exit_order_id).get("data", [])
-                        for f in fills:
-                            fill = Fill(order_id=f["orderId"], trade_id=f["tradeId"], price=float(f["price"]), qty=float(f["qty"]), fee=float(f.get("fee",0)), ts=int(f.get("ts",0)))
+                        data = self.exchange.get_fills(symbol, order_id=st.exit_order_id)
+                        for f in (data.get("data") or []):
+                            fill = Fill(
+                                order_id=str(f.get("orderId") or ""),
+                                trade_id=str(f.get("tradeId") or f.get("fillId") or ""),
+                                price=float(f.get("price", 0)),
+                                qty=float(f.get("qty", 0)),
+                                fee=float(f.get("fee", 0)),
+                                ts=int(f.get("ts", 0)),
+                            )
                             st.apply_fill_exit(fill)
-                    st.last_sync_ts = int(time.time()*1000)
-                    self.pos[symbol] = st
+                        self.pos[symbol] = st
             except Exception as e:
                 print(f"[sync] error: {e!r}")
             await self._sleep(2.0)
+
+    # ---------- Helpers ops ----------
+    def _equity_usdt(self) -> float:
+        try:
+            assets = self.exchange.get_assets()
+            for a in (assets.get("data") or []):
+                if a.get("currency") == "USDT":
+                    return float(a.get("equity", 0))
+        except Exception:
+            pass
+        return 0.0
+
+    async def _flat_symbol(self, symbol: str):
+        st = self.pos.get(symbol)
+        if not st or st.status not in (PositionStatus.OPEN, PositionStatus.PENDING_ENTRY):
+            return False, "no open position"
+        side = "SELL" if st.side == PositionSide.LONG else "BUY"
+        try:
+            out = self.exchange.place_order(symbol=symbol, side=side, quantity=max(st.filled_qty, st.req_qty) or 0.0, order_type="market")
+            st.exit_order_id = str((out.get("data") or {}).get("orderId", "")) if isinstance(out, dict) else st.exit_order_id
+            st.status = PositionStatus.PENDING_EXIT
+            self.pos[symbol] = st
+            return True, "exit submitted"
+        except Exception as e:
+            return False, repr(e)
 
     async def _task_telegram(self):
         if not self._tg.enabled():
@@ -294,12 +321,28 @@ class Orchestrator:
                     low = text.lower()
                     if low.startswith("/status"):
                         await self._tg.send_message(self._status_text())
+                    elif low.startswith("/equity"):
+                        await self._tg.send_message(f"Equity USDT: {self._equity_usdt():.2f}")
                     elif low.startswith("/pause"):
                         self._paused = True
                         await self._tg.send_message("Paused ✅ (no new entries)")
                     elif low.startswith("/resume"):
                         self._paused = False
                         await self._tg.send_message("Resumed ▶️")
+                    elif low.startswith("/flat_all"):
+                        oks = []
+                        for s in list(self.pos.keys()):
+                            ok, _ = await self._flat_symbol(s)
+                            oks.append(f"{s}:{'ok' if ok else 'err'}")
+                        await self._tg.send_message(" ".join(oks) or "none")
+                    elif low.startswith("/flat"):
+                        parts = text.split()
+                        if len(parts) >= 2:
+                            sym = parts[1].replace("_", "").upper()
+                            ok, msg = await self._flat_symbol(sym)
+                            await self._tg.send_message(f"{sym}: {msg}")
+                        else:
+                            await self._tg.send_message("Usage: /flat SYMBOL")
                     elif low.startswith("/symbols"):
                         parts = text.split(None, 1)
                         if len(parts) == 2:
@@ -309,6 +352,8 @@ class Orchestrator:
                                 for s in new_syms:
                                     if s not in self.ctx:
                                         self.ctx[s] = SymbolContext(s, [])
+                                    if s not in self.pos:
+                                        self.pos[s] = PositionState(s, PositionSide.LONG)
                                 await self._tg.send_message(f"Symbols updated: {','.join(self.symbols)}")
                             else:
                                 await self._tg.send_message("Usage: /symbols BTCUSDT,ETHUSDT")
@@ -318,7 +363,8 @@ class Orchestrator:
                         await self._tg.send_message("Closing…")
                         await self.stop(reason="telegram:/close")
                     else:
-                        await self._tg.send_message("Commands: /status, /pause, /resume, /symbols SYM1,SYM2, /close")
+                        await self._tg.send_message(
+                            "Commands: /status, /equity, /pause, /resume, /flat SYMBOL, /flat_all, /symbols SYM1,SYM2, /close")
             except asyncio.CancelledError:
                 break
             except Exception:


### PR DESCRIPTION
## Summary
- track per-symbol position state and sync with exchange
- add helpers to query equity and flatten positions
- extend Telegram commands for equity and flat operations

## Testing
- `pytest` *(fails: cannot import name 'attempt_entry' from 'bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a86e54c6088327a298791b4fae123e